### PR TITLE
Updates cert-manager

### DIFF
--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.6.1
-digest: sha256:42efdf240ca1f4a8d19e8566204dcd50af1532e1e6b0fc9985ba59a00eee2593
-generated: "2023-05-10T12:54:16.395998116+02:00"
+  version: v1.11.3
+digest: sha256:0d39cd958eae42123cbfbec603fd872f6c8ca44009d2e85a3fad4fe586f79578
+generated: "2023-06-15T14:39:08.047212+02:00"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 dependencies:
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: v1.6.1
+    version: v1.11.3
 name: cert-manager
 description: Wrapper chart for cert-manager. Deploys a ClusterIssuer resource to bootstrap Let's encrypt cert generation
-version: 0.2.3
+version: 0.3.0


### PR DESCRIPTION
Updates the cert-manager dependency to 1.11.3, the latest released & working version.

The currently used 1.6.x went EOL in April 2022. [link](https://cert-manager.io/docs/installation/supported-releases/)

Works on k8 1.23 & 1.25, as verified on vibes dev&qa.

An update to 1.12.x is not recommended from the maintainers of cert-manager as the ready-check is broken and the fix is in the not yet released 1.12.2