### PR TITLE
Prepare gatekeeper for dual deployment

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: keycloak-gatekeeper
 name: keycloak-gatekeeper
-version: 1.1.6
+version: 1.1.7
 dependencies:
   - name: gatekeeper
     repository: https://gogatekeeper.github.io/helm-gogatekeeper

--- a/charts/keycloak-gatekeeper/templates/config/no-permission-link-config.yaml
+++ b/charts/keycloak-gatekeeper/templates/config/no-permission-link-config.yaml
@@ -3,4 +3,4 @@ data:
   forbidden.html: <html><head><meta http-equiv='refresh' content='0; URL=https://{{.Values.ingressRoute.domain}}/no-permission'></head></html>
 kind: ConfigMap
 metadata:
-  name: no-permission-link
+  name: {{ .Release.Name }}-no-permission-link

--- a/charts/keycloak-gatekeeper/templates/route/route.yaml
+++ b/charts/keycloak-gatekeeper/templates/route/route.yaml
@@ -11,8 +11,8 @@ spec:
     - kind: Rule
       match: Host(`{{ .Values.ingressRoute.domain }}`)
       services:
-        - name: {{ .Values.ingressRoute.upstream.service.name }}
-          port: {{ .Values.ingressRoute.upstream.service.port }}
+        - name: {{ default (include "gatekeeper.fullname" .) .Values.ingressRoute.upstream.service.name }}
+          port: {{ default .Values.gatekeeper.service.proxy.port .Values.ingressRoute.upstream.service.port }}
   {{- if ne (.Values.ingressRoute.certificate.enabled | toString) "false" }}
   tls:
     secretName: {{ $certSecretName }}

--- a/charts/keycloak-gatekeeper/values.yaml
+++ b/charts/keycloak-gatekeeper/values.yaml
@@ -1,8 +1,9 @@
 ingressRoute:
   upstream:
     service:
-      name: keycloak-gatekeeper
-      port: 3000
+      # If unset like this, defaults to the service of this gatekeeper
+      name:
+      port:
   domain: "my-domain.com"
   entryPointName: "websecure"
   certificate:


### PR DESCRIPTION
For the dual deployment of the gatekeeper (admin/app) 2 changes are necessary for it to work properly:

1. The ConfigMap for the no-permission-link needs to include the release name. If not ArgoCD will let the deployed gatekeepers "fight" over the single ConfigMap (same name of the confirm for each of the gatekeepers)
2.  The ingress-route cannot have an hardcoded service-name as the service-name changes with the release name