### PR TITLE
feat(prometheus-stack): now it is possible to not useless extra resouces

### DIFF
--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
     version: 43.1.3
 description: A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
 name: prometheus-stack
-version: 43.1.5
+version: 43.1.6

--- a/charts/prometheus-stack/templates/route/route-alertmanager.yaml
+++ b/charts/prometheus-stack/templates/route/route-alertmanager.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.prometheusStack.alertmanager.enabled | toString ) "false" }}
+{{- if .Values.prometheusStack.alertmanager.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:

--- a/charts/prometheus-stack/templates/route/route-alertmanager.yaml
+++ b/charts/prometheus-stack/templates/route/route-alertmanager.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.prometheusStack.alertmanager.enabled | toString ) "false" }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -17,3 +18,4 @@ spec:
           namespace: {{.Release.Namespace}}
           passHostHeader: true
           port: 9093
+{{- end }}

--- a/charts/prometheus-stack/templates/route/route-grafana.yaml
+++ b/charts/prometheus-stack/templates/route/route-grafana.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.prometheusStack.grafana.enabled | toString ) "false" }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -17,3 +18,4 @@ spec:
           namespace: {{.Release.Namespace}}
           passHostHeader: true
           port: 80
+{{- end }}

--- a/charts/prometheus-stack/templates/route/route-grafana.yaml
+++ b/charts/prometheus-stack/templates/route/route-grafana.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.prometheusStack.grafana.enabled | toString ) "false" }}
+{{- if .Values.prometheusStack.grafana.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:

--- a/charts/prometheus-stack/templates/route/route-prometheus.yaml
+++ b/charts/prometheus-stack/templates/route/route-prometheus.yaml
@@ -1,3 +1,4 @@
+{{- if ne (.Values.prometheusStack.prometheus.enabled | toString ) "false" }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -14,3 +15,4 @@ spec:
           namespace: {{.Release.Namespace}}
           passHostHeader: true
           port: 9090
+{{- end }}

--- a/charts/prometheus-stack/templates/route/route-prometheus.yaml
+++ b/charts/prometheus-stack/templates/route/route-prometheus.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.prometheusStack.prometheus.enabled | toString ) "false" }}
+{{- if .Values.prometheusStack.prometheus.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:


### PR DESCRIPTION
#77 
With this changes extra routes will not be created if there is enabled: false in parent chart for them.