### PR TITLE
Prometheus upgrade to 2.50

### DIFF
--- a/charts/prometheus-stack/Chart.lock
+++ b/charts/prometheus-stack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 43.1.3
-digest: sha256:1384ed7bfda30122338ae6d34f055d287533edd7c377aef1cd915b3468412879
-generated: "2023-05-10T12:54:26.18464468+02:00"
+  version: 56.21.4
+digest: sha256:acedc6fbd019fb5b49e6103c9c60b88d054b2ac550f3286ba6d90fe84a2c1878
+generated: "2024-03-12T11:00:37.565826+01:00"

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -3,7 +3,7 @@ dependencies:
   - alias: prometheusStack
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 43.1.3
+    version: 56.21.x
 description: |
   A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
   
@@ -27,4 +27,4 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 43.3.0
+version: 56.21.0

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -113,6 +113,8 @@ prometheusStack:
       patch:
         enabled: false
   grafana:
+    serviceMonitor:
+      path: "/grafana/metrics"
     # -- Required
     adminPassword:
     grafana.ini:


### PR DESCRIPTION
Changes Prometheus Version from 2.40 -> 2.50

Fixes ServiceMonitor path for Grafana

