### PR TITLE
Update Gatekeeper (forward-auth) to 3.0.2

### DIFF
--- a/charts/oidc-forward-auth/Changelog.MD
+++ b/charts/oidc-forward-auth/Changelog.MD
@@ -1,6 +1,7 @@
 ### Chart version: 1.7.0
  - AppVersion update to 3.0.2
  - encryption-key is now required by default
+ - Gatekeeper will now refresh the cookie in the browser and also encrypt the token.
 
 ### Chart version: 1.6.2
  - Security settings for pod

--- a/charts/oidc-forward-auth/Changelog.MD
+++ b/charts/oidc-forward-auth/Changelog.MD
@@ -1,3 +1,7 @@
+### Chart version: 1.7.0
+ - AppVersion update to 3.0.2
+ - encryption-key is now required by default
+
 ### Chart version: 1.6.2
  - Security settings for pod
  - AppVersion update to 2.14.3

--- a/charts/oidc-forward-auth/Chart.lock
+++ b/charts/oidc-forward-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gatekeeper
   repository: https://gogatekeeper.github.io/helm-gogatekeeper
-  version: 0.1.50
-digest: sha256:dd77b07d0cbcb477d733bf01bb8e20831679c8da99e4bbce7ed5182e42008ef8
-generated: "2024-10-14T17:12:52.753392+02:00"
+  version: 0.1.51
+digest: sha256:6a864255a5562a316b67e7e30a0bc6af20a33331b63985919b27537ddf15eedf
+generated: "2025-01-16T12:00:25.046636+01:00"

--- a/charts/oidc-forward-auth/Chart.yaml
+++ b/charts/oidc-forward-auth/Chart.yaml
@@ -8,10 +8,11 @@ description: |
   charts:
     oidc-forward-auth:
       namespace: routing
-      targetRevision: "1.6.2"
+      targetRevision: "1.7.0"
       parameters:
         gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
         gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
+        gatekeeper.config.encryption-key: "${vault:whatever/data/keycloak/keycloak_proxy_admin#encryption-key}"
         gatekeeper.config.discovery-url: "https://{{.Values.projectValues.authDomain}}/realms/{{.Values.projectValues.context}}"
         ingress.host: "my.protected.domain"
   ```
@@ -34,7 +35,7 @@ description: |
       enabled: true
   ```
 name: oidc-forward-auth
-version: 1.6.2
+version: 1.7.0
 dependencies:
   - name: gatekeeper
     repository: https://gogatekeeper.github.io/helm-gogatekeeper

--- a/charts/oidc-forward-auth/Chart.yaml
+++ b/charts/oidc-forward-auth/Chart.yaml
@@ -38,5 +38,5 @@ version: 1.6.2
 dependencies:
   - name: gatekeeper
     repository: https://gogatekeeper.github.io/helm-gogatekeeper
-    version: 0.1.50
+    version: 0.1.51
 

--- a/charts/oidc-forward-auth/README.md
+++ b/charts/oidc-forward-auth/README.md
@@ -39,7 +39,7 @@ ingress:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.50 |
+| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.51 |
 
 ## Values
 
@@ -70,7 +70,7 @@ ingress:
 | gatekeeper.config.server-write-timeout | string | `"10s"` |  |
 | gatekeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | gatekeeper.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| gatekeeper.image.tag | string | `"2.14.3"` |  |
+| gatekeeper.image.tag | string | `"3.0.2"` |  |
 | gatekeeper.livenessProbe.enabled | bool | `true` |  |
 | gatekeeper.replicaCount | int | `2` |  |
 | gatekeeper.resources.limits.cpu | string | `"100m"` |  |
@@ -84,6 +84,8 @@ ingress:
 | ingress.host | string | `nil` | Required, replace it with your host address |
 | ingress.hosts[0].host | string | `"{{ .Values.ingress.host }}"` |  |
 | ingress.hosts[0].paths[0].path | string | `"/oauth"` |  |
+| middleware.addAuthCookiesToResponse[0] | string | `"kc-access"` |  |
+| middleware.addAuthCookiesToResponse[1] | string | `"kc-state"` |  |
 | middleware.address | string | `"http://{{ include \"oidc-forward-auth.fullname\" $ }}-gatekeeper.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.gatekeeper.service.proxy.port }}"` |  |
 | middleware.authRequestHeaders[0] | string | `"Accept"` |  |
 | middleware.authRequestHeaders[1] | string | `"Authorization"` |  |

--- a/charts/oidc-forward-auth/README.md
+++ b/charts/oidc-forward-auth/README.md
@@ -1,6 +1,6 @@
 # oidc-forward-auth
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square)
 
 Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 
@@ -10,10 +10,11 @@ Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 charts:
   oidc-forward-auth:
     namespace: routing
-    targetRevision: "1.6.2"
+    targetRevision: "1.7.0"
     parameters:
       gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
       gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
+      gatekeeper.config.encryption-key: "${vault:whatever/data/keycloak/keycloak_proxy_admin#encryption-key}"
       gatekeeper.config.discovery-url: "https://{{.Values.projectValues.authDomain}}/realms/{{.Values.projectValues.context}}"
       ingress.host: "my.protected.domain"
 ```
@@ -58,7 +59,7 @@ ingress:
 | gatekeeper.config.enable-refresh-tokens | bool | `true` |  |
 | gatekeeper.config.enable-request-id | bool | `true` |  |
 | gatekeeper.config.enable-token-header | bool | `false` |  |
-| gatekeeper.config.encryption-key | string | `nil` | Highly Recommended: encryption key used to encryption the session state |
+| gatekeeper.config.encryption-key | string | `nil` | Required: encryption key used to encryption the session state |
 | gatekeeper.config.listen | string | `"0.0.0.0:3000"` |  |
 | gatekeeper.config.listen-admin | string | `":4000"` |  |
 | gatekeeper.config.no-proxy | bool | `true` |  |

--- a/charts/oidc-forward-auth/values.yaml
+++ b/charts/oidc-forward-auth/values.yaml
@@ -34,7 +34,7 @@ gatekeeper:
     # -- Required: discovery url to retrieve the openid configuration, i.e. "https://keycloak.example.com/realms/<realm>"
     discovery-url:
 
-    # -- Highly Recommended: encryption key used to encryption the session state
+    # -- Required: encryption key used to encryption the session state
     encryption-key:
 
     # important: do not proxy requests to upstream, useful for forward-auth usage (with nginx, traefik)

--- a/charts/oidc-forward-auth/values.yaml
+++ b/charts/oidc-forward-auth/values.yaml
@@ -16,7 +16,7 @@ gatekeeper:
     enabled: true
 
   image:
-    tag: 2.14.3
+    tag: 3.0.2
 
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -104,6 +104,10 @@ middleware:
   authResponseHeaders:
     - "Authorization"
     - "Set-Cookie"
+
+  addAuthCookiesToResponse:
+    - "kc-access"
+    - "kc-state"
 
 ingress:
   enabled: true


### PR DESCRIPTION
 - also fixes that the browser does not get the refreshed token
 - Browser cookies are now encrypted by default (gatekeeper new default)