### PR TITLE
introduce audit mode in image signing policy

### DIFF
--- a/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
+++ b/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
@@ -16,7 +16,11 @@ spec:
   validationFailureAction: {{ .validationAction }}
   background: {{ .background }}
   webhookTimeoutSeconds: {{ .timeout }}
+  {{- if eq $.Values.imageSigning.failurePolicy "Audit" }}
+  mutateDigest: false
+  {{- else }}
   failurePolicy: Fail
+  {{- end }}
   rules:
     - name: "{{ .name }}-rule"
       match:

--- a/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
+++ b/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
@@ -16,9 +16,7 @@ spec:
   validationFailureAction: {{ .validationAction }}
   background: {{ .background }}
   webhookTimeoutSeconds: {{ .timeout }}
-  {{- if eq $.Values.imageSigning.failurePolicy "Audit" }}
-  mutateDigest: false
-  {{- else }}
+  {{- if eq $.Values.imageSigning.failurePolicy "Enforce" }}
   failurePolicy: Fail
   {{- end }}
   rules:
@@ -46,7 +44,11 @@ spec:
             secrets:
               - {{ .pullSecret }}
           {{- end }}
+          {{- if eq $.Values.imageSigning.failurePolicy "Enforce" }}
           mutateDigest: true
+          {{- else }}
+          mutateDigest: false
+          {{- end }}
           requireDigest: true
           attestors:
             - entries:

--- a/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
+++ b/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
@@ -16,7 +16,7 @@ spec:
   validationFailureAction: {{ .validationAction }}
   background: {{ .background }}
   webhookTimeoutSeconds: {{ .timeout }}
-  {{- if eq $.Values.imageSigning.failurePolicy "Enforce" }}
+  {{- if eq $.Values.disallowUnsignedImages.validationAction "Enforce" }}
   failurePolicy: Fail
   {{- end }}
   rules:
@@ -44,7 +44,7 @@ spec:
             secrets:
               - {{ .pullSecret }}
           {{- end }}
-          {{- if eq $.Values.imageSigning.failurePolicy "Enforce" }}
+          {{- if eq $.Values.disallowUnsignedImages.validationAction "Enforce" }}
           mutateDigest: true
           requireDigest: true
           {{- else }}

--- a/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
+++ b/charts/kyverno/templates/policies/disallow-unsigned-images.yaml
@@ -46,10 +46,10 @@ spec:
           {{- end }}
           {{- if eq $.Values.imageSigning.failurePolicy "Enforce" }}
           mutateDigest: true
+          requireDigest: true
           {{- else }}
           mutateDigest: false
           {{- end }}
-          requireDigest: true
           attestors:
             - entries:
                 - keys:


### PR DESCRIPTION
In Audit mode "mutateDigest" must be set to false.