### PR TITLE
chore(kyverno): update the stacks Helm Chart versions

### DIFF
--- a/charts/kyverno/Changelog.MD
+++ b/charts/kyverno/Changelog.MD
@@ -2,6 +2,12 @@
 
 ## Chart Versions
 
+### 2.4.0
+
+- Update kyverno Chart to 3.4.0
+- Update kyverno-policies to 3.4.0
+- Update policy-reported to 3.1.3
+
 ### 2.3.0
 
 - fixed a bug that caused jobs to not count as completed even if the underlying pod finished successfully

--- a/charts/kyverno/Changelog.MD
+++ b/charts/kyverno/Changelog.MD
@@ -1,29 +1,38 @@
-### Chart Version 2.3.0
+# Changelog
+
+## Chart Versions
+
+### 2.3.0
+
 - fixed a bug that caused jobs to not count as completed even if the underlying pod finished successfully
 - reworked the internal structure of our custom policies, some parameters change please check if you have overriden some
 - Updated kyverno to Chart 3.3.7 / AppVersion 1.13.4
 - Updated kyverno-policies to 3.3.4
 - Updated policy-reported to 3.0.7
 
-### Chart Version 2.2.2
+### 2.2.2
+
 - PolicyExceptions are now toggled on by default
 
-### Chart Version 2.2.1
+### 2.2.1
+
 - Fixed an issue with missing rbac parameter for the admission controller
 
-### Chart Version 2.2.0
+### 2.2.0
+
 - Update kyverno Chart to 3.3.4 & AppVersion to 1.13.2
 - Update kyverno-policies to 3.3.2
 - Update policy-reported to 3.0.0
 
-Note: 
- - There were changes in the CRDs, you have to update them **before** updating. 
- - Rolling Updates do not work if you come from 2.1.x.
- - It is recommended to completely uninstall the old version first, then update the CRDs and then install the new version.
+Note:
 
-### Chart Version 2.1.1
+- There were changes in the CRDs, you have to update them **before** updating.
+- Rolling Updates do not work if you come from 2.1.x.
+- It is recommended to completely uninstall the old version first, then update the CRDs and then install the new version.
 
- - Update kyverno Chart to 3.2.7 & AppVersion to 1.12.6
- - Update kyverno-policies to 3.2.6
- - Update policy-reported to 2.24.2
- - No migrations necessary.
+### 2.1.1
+
+- Update kyverno Chart to 3.2.7 & AppVersion to 1.12.6
+- Update kyverno-policies to 3.2.6
+- Update policy-reported to 2.24.2
+- No migrations necessary.

--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kyverno
   repository: https://kyverno.github.io/kyverno/
-  version: 3.3.7
+  version: 3.4.0
 - name: kyverno-policies
   repository: https://kyverno.github.io/kyverno/
-  version: 3.3.4
+  version: 3.4.0
 - name: policy-reporter
   repository: https://kyverno.github.io/policy-reporter
-  version: 3.0.7
-digest: sha256:5dc5ac47b78900a363f86942e4d89ab019d18be6771c69fef087507c786f614c
-generated: "2025-03-26T17:49:17.095354+01:00"
+  version: 3.1.3
+digest: sha256:ce00956328ae65ec8568c2a0a602676779505f222fc8f9eeab28264cd4ef6bf9
+generated: "2025-04-29T15:04:49.624789+02:00"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -9,14 +9,14 @@ description: |
 dependencies:
   - name: "kyverno"
     repository: "https://kyverno.github.io/kyverno/"
-    version: 3.3.7
+    version: 3.4.0
   - name: "kyverno-policies"
     repository: "https://kyverno.github.io/kyverno/"
-    version: 3.3.4
+    version: 3.4.0
   - name: "policy-reporter"
     repository: "https://kyverno.github.io/policy-reporter"
-    version: 3.0.7
+    version: 3.1.3
     condition: policy-reporter.install
 type: application
-version: 2.3.0
+version: 2.4.0
 appVersion: 1.13.4

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -1,6 +1,6 @@
 # kyverno
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.4](https://img.shields.io/badge/AppVersion-1.13.4-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.4](https://img.shields.io/badge/AppVersion-1.13.4-informational?style=flat-square)
 
 This chart wraps the upstream `kyverno` and `kyverno-policies` chart and adds a few useful policies:
   - Verify all images are signed with cosign
@@ -12,9 +12,9 @@ This chart wraps the upstream `kyverno` and `kyverno-policies` chart and adds a 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://kyverno.github.io/kyverno/ | kyverno | 3.3.7 |
-| https://kyverno.github.io/kyverno/ | kyverno-policies | 3.3.4 |
-| https://kyverno.github.io/policy-reporter | policy-reporter | 3.0.7 |
+| https://kyverno.github.io/kyverno/ | kyverno | 3.4.0 |
+| https://kyverno.github.io/kyverno/ | kyverno-policies | 3.4.0 |
+| https://kyverno.github.io/policy-reporter | policy-reporter | 3.1.3 |
 
 ## Values
 


### PR DESCRIPTION
## Summary
- updated `chartVersion` for kyverno to `3.4.0`
- updated `chartVersion` for kyverno-policies to `3.4.0`
- updated `chartVersion` for policy-reporter to `3.1.3`
- adjusted the Helm chart version accordingly

## Testing
- verified the updated chart on the Playground environment
- confirmed that the deployment behaves as expected