### PR TITLE
chore(gatekeeper): update to chartVersion to 0.1.54

### DIFF
--- a/charts/oidc-forward-auth/Changelog.MD
+++ b/charts/oidc-forward-auth/Changelog.MD
@@ -2,10 +2,16 @@
 
 ## Changelog Versions
 
+### 1.8.0
+- Update gogatekeeper helm chart version to 0.1.54
+- Update AppVersion to 3.3.0
+
 ### 1.7.1
 
-- Update gogatekeeper helm chart version to 0.1.54
-- bump helm chart version to 1.7.1
+- Drop the authResponseHeaders from the middleware
+  - gogatekeeper will no longer Override the `Authentication` header a client might send.
+- Disable encryption of the access-token cookie.
+  - this way automated clients can still interact with protected domains.
 
 ### 1.7.0
 

--- a/charts/oidc-forward-auth/Changelog.MD
+++ b/charts/oidc-forward-auth/Changelog.MD
@@ -1,9 +1,15 @@
-### Chart version: 1.7.0
- - AppVersion update to 3.0.2
- - encryption-key is now required by default
- - Gatekeeper will now refresh the cookie in the browser and also encrypt the token.
+# Changelog
 
-### Chart version: 1.6.2
- - Security settings for pod
- - AppVersion update to 2.14.3
- - No migrations necessary
+## Changelog Versions
+
+### 1.7.0
+
+- AppVersion update to 3.0.2
+- encryption-key is now required by default
+- Gatekeeper will now refresh the cookie in the browser and also encrypt the token.
+
+### 1.6.2
+
+- Security settings for pod
+- AppVersion update to 2.14.3
+- No migrations necessary

--- a/charts/oidc-forward-auth/Changelog.MD
+++ b/charts/oidc-forward-auth/Changelog.MD
@@ -2,6 +2,11 @@
 
 ## Changelog Versions
 
+### 1.7.1
+
+- Update gogatekeeper helm chart version to 0.1.54
+- bump helm chart version to 1.7.1
+
 ### 1.7.0
 
 - AppVersion update to 3.0.2

--- a/charts/oidc-forward-auth/Chart.lock
+++ b/charts/oidc-forward-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gatekeeper
   repository: https://gogatekeeper.github.io/helm-gogatekeeper
-  version: 0.1.51
-digest: sha256:6a864255a5562a316b67e7e30a0bc6af20a33331b63985919b27537ddf15eedf
-generated: "2025-01-16T12:00:25.046636+01:00"
+  version: 0.1.54
+digest: sha256:b843e6fde578d68b600123a83d1219258a014e102a29971ee23d5b7fde2ece81
+generated: "2025-04-30T09:08:54.125865+02:00"

--- a/charts/oidc-forward-auth/Chart.yaml
+++ b/charts/oidc-forward-auth/Chart.yaml
@@ -39,5 +39,5 @@ version: 1.7.1
 dependencies:
   - name: gatekeeper
     repository: https://gogatekeeper.github.io/helm-gogatekeeper
-    version: 0.1.51
+    version: 0.1.54
 

--- a/charts/oidc-forward-auth/Chart.yaml
+++ b/charts/oidc-forward-auth/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 description: |
-  Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
-  
+  Traefik forward auth with gogatekeeper.
+
   ## Installing the Chart with iits ArgoCD
 
   ```yaml
   charts:
     oidc-forward-auth:
       namespace: routing
-      targetRevision: "1.7.1"
+      targetRevision: "1.7.2"
       parameters:
         gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
         gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
@@ -22,20 +22,12 @@ description: |
 
   ```yaml
   ingress:
-    enabled: true
-    # -- Mandatory, replace it with your host address
-    host: 
-    annotations:
-      traefik.ingress.kubernetes.io/router.entrypoints: websecure
-      traefik.ingress.kubernetes.io/router.tls: "true"
-      #namespace-name@kubernetescrd
+      annotations:
+      # Value Pattern: <namespace>-<name>@kubernetescrd
       traefik.ingress.kubernetes.io/router.middlewares: routing-oidc-forward-auth@kubernetescrd
-    # Creates default Ingress with tls and the given host from .Values.ingress.host
-    defaultIngress:
-      enabled: true
   ```
 name: oidc-forward-auth
-version: 1.7.1
+version: 1.7.2
 dependencies:
   - name: gatekeeper
     repository: https://gogatekeeper.github.io/helm-gogatekeeper

--- a/charts/oidc-forward-auth/Chart.yaml
+++ b/charts/oidc-forward-auth/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   charts:
     oidc-forward-auth:
       namespace: routing
-      targetRevision: "1.7.0"
+      targetRevision: "1.7.1"
       parameters:
         gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
         gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"

--- a/charts/oidc-forward-auth/README.md
+++ b/charts/oidc-forward-auth/README.md
@@ -1,8 +1,8 @@
 # oidc-forward-auth
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square)
 
-Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
+Traefik forward auth with gogatekeeper.
 
 ## Installing the Chart with iits ArgoCD
 
@@ -10,7 +10,7 @@ Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 charts:
   oidc-forward-auth:
     namespace: routing
-    targetRevision: "1.7.0"
+    targetRevision: "1.7.2"
     parameters:
       gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
       gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
@@ -23,24 +23,16 @@ charts:
 
 ```yaml
 ingress:
-  enabled: true
-  # -- Mandatory, replace it with your host address
-  host:
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
-    #namespace-name@kubernetescrd
+    annotations:
+    # Value Pattern: <namespace>-<name>@kubernetescrd
     traefik.ingress.kubernetes.io/router.middlewares: routing-oidc-forward-auth@kubernetescrd
-  # Creates default Ingress with tls and the given host from .Values.ingress.host
-  defaultIngress:
-    enabled: true
 ```
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.51 |
+| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.54 |
 
 ## Values
 
@@ -56,7 +48,7 @@ ingress:
 | gatekeeper.config.enable-json-logging | bool | `true` |  |
 | gatekeeper.config.enable-logging | bool | `false` |  |
 | gatekeeper.config.enable-logout-redirect | bool | `true` |  |
-| gatekeeper.config.enable-metrics | bool | `false` |  |
+| gatekeeper.config.enable-metrics | bool | `true` |  |
 | gatekeeper.config.enable-refresh-tokens | bool | `true` |  |
 | gatekeeper.config.enable-request-id | bool | `true` |  |
 | gatekeeper.config.enable-token-header | bool | `false` |  |
@@ -72,13 +64,12 @@ ingress:
 | gatekeeper.config.server-write-timeout | string | `"10s"` |  |
 | gatekeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | gatekeeper.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| gatekeeper.image.tag | string | `"3.0.2"` |  |
 | gatekeeper.livenessProbe.enabled | bool | `true` |  |
+| gatekeeper.metrics.serviceMonitor.enabled | bool | `true` |  |
 | gatekeeper.replicaCount | int | `2` |  |
-| gatekeeper.resources.limits.cpu | string | `"100m"` |  |
-| gatekeeper.resources.limits.memory | string | `"128Mi"` |  |
+| gatekeeper.resources.limits.memory | string | `"100Mi"` |  |
 | gatekeeper.resources.requests.cpu | string | `"10m"` |  |
-| gatekeeper.resources.requests.memory | string | `"16Mi"` |  |
+| gatekeeper.resources.requests.memory | string | `"100Mi"` |  |
 | gatekeeper.strategy.type | string | `"RollingUpdate"` |  |
 | ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |
 | ingress.annotations."traefik.ingress.kubernetes.io/router.tls" | string | `"true"` |  |

--- a/charts/oidc-forward-auth/README.md
+++ b/charts/oidc-forward-auth/README.md
@@ -10,7 +10,7 @@ Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 charts:
   oidc-forward-auth:
     namespace: routing
-    targetRevision: "1.7.0"
+    targetRevision: "1.7.1"
     parameters:
       gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
       gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
@@ -40,7 +40,7 @@ ingress:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.51 |
+| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.54 |
 
 ## Values
 

--- a/charts/oidc-forward-auth/README.md
+++ b/charts/oidc-forward-auth/README.md
@@ -1,6 +1,6 @@
 # oidc-forward-auth
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square)
 
 Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 
@@ -10,7 +10,7 @@ Forward Auth proxy with gogatekeeper. It replaces the old proxy mechanism
 charts:
   oidc-forward-auth:
     namespace: routing
-    targetRevision: "1.7.1"
+    targetRevision: "1.7.0"
     parameters:
       gatekeeper.config.client-id: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_id}"
       gatekeeper.config.client-secret: "${vault:whatever/data/keycloak/keycloak_proxy_admin#client_secret}"
@@ -40,7 +40,7 @@ ingress:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.54 |
+| https://gogatekeeper.github.io/helm-gogatekeeper | gatekeeper | 0.1.51 |
 
 ## Values
 

--- a/charts/oidc-forward-auth/values.yaml
+++ b/charts/oidc-forward-auth/values.yaml
@@ -6,17 +6,17 @@ gatekeeper:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 128Mi
+      memory: 100Mi
     requests:
       cpu: 10m
-      memory: 16Mi
+      memory: 100Mi
 
   livenessProbe:
     enabled: true
 
-  image:
-    tag: 3.0.2
+  metrics:
+    serviceMonitor:
+      enabled: true
 
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -74,7 +74,7 @@ gatekeeper:
     enable-logging: false
 
     #enable the prometheus metrics collector on /oauth/metrics
-    enable-metrics: false
+    enable-metrics: true
 
     # defines the binding interface for main listener, e.g. {address}:{port}. This is required and there is no default value
     listen: 0.0.0.0:3000


### PR DESCRIPTION
## Summary
- updated `chartVersion` for gatekeeper to `0.1.54`
- adjusted the Helm chart version accordingly

## Testing
- verified the updated chart on the Playground environment
- confirmed that the deployment behaves as expected