### PR TITLE
chore(prometheus-stack): update to chartVersion 71.0.0

### DIFF
--- a/charts/prometheus-stack/CHANGELOG.md
+++ b/charts/prometheus-stack/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Chart Versions
+
+### 71.0.0
+
+- Update chart version to 71.0.0

--- a/charts/prometheus-stack/Chart.lock
+++ b/charts/prometheus-stack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 68.4.5
-digest: sha256:a02ac03890f77e1ca66758a0154ae32ac3d6bd52480b622ee62ee42ff1b3f3a9
-generated: "2025-02-04T15:00:01.939212+01:00"
+  version: 71.0.0
+digest: sha256:75acd327b42ca5ca16779d99af789a1f41d223b61a50e0ed34fcc092042b991a
+generated: "2025-04-30T09:43:04.023404+02:00"

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -3,7 +3,7 @@ dependencies:
   - alias: prometheusStack
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 68.4.5
+    version: 71.0.0
 description: |
   A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
   
@@ -13,7 +13,7 @@ description: |
   prometheus-stack:
     namespace: monitoring
     repoURL: "https://charts.iits.tech"
-    targetRevision: "68.4.5"
+    targetRevision: "71.0.0"
     ignoreDifferences:
       - jsonPointers:
           - /imagePullSecrets
@@ -27,5 +27,5 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 68.4.5
-appVersion: 68.4.5
+version: 71.0.0
+appVersion: 71.0.0

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,6 +1,6 @@
 # prometheus-stack
 
-![Version: 68.4.5](https://img.shields.io/badge/Version-68.4.5-informational?style=flat-square) ![AppVersion: 68.4.5](https://img.shields.io/badge/AppVersion-68.4.5-informational?style=flat-square)
+![Version: 71.0.0](https://img.shields.io/badge/Version-71.0.0-informational?style=flat-square) ![AppVersion: 71.0.0](https://img.shields.io/badge/AppVersion-71.0.0-informational?style=flat-square)
 
 A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
 
@@ -10,7 +10,7 @@ A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
 prometheus-stack:
   namespace: monitoring
   repoURL: "https://charts.iits.tech"
-  targetRevision: "68.4.5"
+  targetRevision: "71.0.0"
   ignoreDifferences:
     - jsonPointers:
         - /imagePullSecrets
@@ -28,7 +28,7 @@ prometheus-stack:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 68.4.5 |
+| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 71.0.0 |
 
 ## Values
 


### PR DESCRIPTION
## Summary
- updated `chartVersion` for kube-prometheus-stack to `71.0.0`
- adjusted the Helm chart version accordingly

## Testing
- verified the updated chart on the Playground environment
- confirmed that the deployment behaves as expected