### PR TITLE
feat(elastic-operator): bump stack to v9.0.1

### DIFF
--- a/charts/elastic-operator/Changelog.md
+++ b/charts/elastic-operator/Changelog.md
@@ -2,6 +2,12 @@
 
 ## Chart Versions
 
+### BREAKING CHANGE 9.0.0
+
+- app version update to 9.0.0
+
+> Important: The upgrade to version 9.x requires a specific upgrade path (the latest upgrade path can be found [here](https://www.elastic.co/docs/deploy-manage/upgrade/prepare-to-upgrade#prepare-upgrade-from-8.x)). Before installing version 9.0.0, a version update to 8.18.1 must be made, otherwise the upgrade will fail. use "8.18.1-fb-migr-filestream" from our stack for easy upgrading
+
 ### 8.18.1-fb-migr-filestream
 
 > Important: In preparation for the upgrade to version 9.0.0, this update must be installed as part of the upgrade path. Otherwise Filebeat will not be functional after upgrading to v9.0.0.
@@ -15,6 +21,7 @@ Following the official [migration guide](https://www.elastic.co/docs/reference/b
 ### 8.18.1-fb-tolerations
 
 - fixed a bug in the Helm chart that caused tolerations rendering to fail for Filebeat
+
 
 ### 8.18.1
 

--- a/charts/elastic-operator/Changelog.md
+++ b/charts/elastic-operator/Changelog.md
@@ -2,11 +2,11 @@
 
 ## Chart Versions
 
-### BREAKING CHANGE 9.0.0
+### BREAKING CHANGE 9.0.1
 
-- app version update to 9.0.0
+- app version update to 9.0.1
 
-> Important: The upgrade to version 9.x requires a specific upgrade path (the latest upgrade path can be found [here](https://www.elastic.co/docs/deploy-manage/upgrade/prepare-to-upgrade#prepare-upgrade-from-8.x)). Before installing version 9.0.0, a version update to 8.18.1 must be made, otherwise the upgrade will fail. use "8.18.1-fb-migr-filestream" from our stack for easy upgrading
+> Important: The upgrade to version 9.x requires a specific upgrade path (the latest upgrade path can be found [here](https://www.elastic.co/docs/deploy-manage/upgrade/prepare-to-upgrade#prepare-upgrade-from-8.x)). Before installing version 9.0.0, a version update to 8.18.1 must be made, otherwise the upgrade will fail. Use version "8.18.1-fb-migr-filestream" from our stack for easy upgrading.
 
 ### 8.18.1-fb-migr-filestream
 
@@ -21,7 +21,6 @@ Following the official [migration guide](https://www.elastic.co/docs/reference/b
 ### 8.18.1-fb-tolerations
 
 - fixed a bug in the Helm chart that caused tolerations rendering to fail for Filebeat
-
 
 ### 8.18.1
 

--- a/charts/elastic-operator/Chart.yaml
+++ b/charts/elastic-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: elastic-operator
-version: 8.18.1-fb-migr-filestream
-appVersion: 8.18.1
+version: 9.0.0
+appVersion: 9.0.0
 dependencies:
   - name: eck-operator
     repository: https://helm.elastic.co

--- a/charts/elastic-operator/Chart.yaml
+++ b/charts/elastic-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: elastic-operator
-version: 9.0.0
-appVersion: 9.0.0
+version: 9.0.1
+appVersion: 9.0.1
 dependencies:
   - name: eck-operator
     repository: https://helm.elastic.co

--- a/charts/elastic-operator/MIGRATION.md
+++ b/charts/elastic-operator/MIGRATION.md
@@ -5,7 +5,7 @@ Generally updates should just work in-place. But:
 * Have a backup at hand - just in case
 * Make sure that the persistent volumes of elasticsearch have "Retain" as their reclaim policy and wont get deleted at any point
 * Check out the settings of the new chart. They should be compatible with the ones from elasticsearch chart (at least for the default config). But take a look at them and configure the chart. Some keys and locations of settings might have changed.
-* tested from elasticsearch `8.5.1` to `8.18.1` (you can configure the version of elasticsearch in elastic-operator chart)
+* tested from elasticsearch `8.5.1` to `9.0.0` (you can configure the version of elasticsearch in elastic-operator chart)
 * check out the [docs](https://www.elastic.co/docs/deploy-manage/upgrade/prepare-to-upgrade) on how to prepare for an upgrade
 
 ## The migration process

--- a/charts/elastic-operator/README.md
+++ b/charts/elastic-operator/README.md
@@ -79,7 +79,6 @@ It comes also with a backup functionality. This is the version using ECK-operato
 | filebeat.autodiscover.providers[0].hints.default_config.paths[0] | string | `"/var/log/containers/*${data.kubernetes.container.id}.log"` |  |
 | filebeat.autodiscover.providers[0].hints.default_config.prospector.scanner."fingerprint.enabled" | bool | `true` |  |
 | filebeat.autodiscover.providers[0].hints.default_config.prospector.scanner.symlinks | bool | `true` |  |
-| filebeat.autodiscover.providers[0].hints.default_config.take_over | bool | `true` |  |
 | filebeat.autodiscover.providers[0].hints.default_config.type | string | `"filestream"` |  |
 | filebeat.autodiscover.providers[0].hints.enabled | bool | `true` |  |
 | filebeat.autodiscover.providers[0].node | string | `"${NODE_NAME}"` |  |

--- a/charts/elastic-operator/README.md
+++ b/charts/elastic-operator/README.md
@@ -1,6 +1,6 @@
 # elastic-operator
 
-![Version: 8.18.1-fb-migr-filestream](https://img.shields.io/badge/Version-8.18.1--fb--migr--filestream-informational?style=flat-square) ![AppVersion: 8.18.1](https://img.shields.io/badge/AppVersion-8.18.1-informational?style=flat-square)
+![Version: 9.0.1](https://img.shields.io/badge/Version-9.0.1-informational?style=flat-square) ![AppVersion: 9.0.1](https://img.shields.io/badge/AppVersion-9.0.1-informational?style=flat-square)
 
 Elasticsearch + filebeat + kibana with default common used indexes and Index Lifecycle Management.
 It comes also with a backup functionality. This is the version using ECK-operator to deploy and monitor the stack.

--- a/charts/elastic-operator/values.yaml
+++ b/charts/elastic-operator/values.yaml
@@ -160,7 +160,6 @@ filebeat:
               scanner:
                 fingerprint.enabled: true
                 symlinks: true
-            take_over: true
             type: filestream
           enabled: true
   # default processors


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change that requires a specific upgrade path. View the CHANGELOG.md for more information.

## Summary
- update `appVersion` for elastic to `9.0.1`
- adjusted the Helm chart version accordingly
- added disclaimer for upgrade path to version 9.0.0 in CHANGELOG.md

## Testing
- verified the updated chart on the Playground environment
![image](https://github.com/user-attachments/assets/d77654fa-1e9b-447e-8656-b2a53c5e8a3d)
- confirmed that the deployment behaves as expected