### PR TITLE
docs(elastic-operator): add entry for v8.18.1-fb-tolerations to CHANGELOG.md

### DIFF
--- a/charts/elastic-operator/Changelog.md
+++ b/charts/elastic-operator/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Chart Versions
 
+### 8.18.1-fb-tolerations
+
+- fixed a bug in the Helm chart that caused tolerations rendering to fail for Filebeat
+
 ### 8.18.1
 
 - app version update to 8.18.1


### PR DESCRIPTION
The release version 8.18.1-fb-tolerations is missing the changes in the CHANGELOG.md (#163 . This PR adds those.