### PR TITLE
feat(filebeat): prepare migration from deprecated container input to filestream

### DIFF
--- a/charts/elastic-operator/Changelog.md
+++ b/charts/elastic-operator/Changelog.md
@@ -2,6 +2,16 @@
 
 ## Chart Versions
 
+### 8.18.1-fb-migr-filestream
+
+> Important: In preparation for the upgrade to version 9.0.0, this update must be installed as part of the upgrade path. Otherwise Filebeat will not be functional after upgrading to v9.0.0.
+
+The `container` input for Filebeat was deprecated in version `7.16` and is completely disabled by version `9.0.0` (see [#42295](https://github.com/elastic/beats/pull/42295)).
+Following the official [migration guide](https://www.elastic.co/docs/reference/beats/filebeat/migrate-to-filestream), in preparation for the migration from `container` input to `filestream`, a specific tag `take_over` must be set, so Filebeat can separate logs created by the container input from the filestream input. Otherwise an error is thrown and data may be duplicated.
+
+- this Helm chart version adds the `filestream` input and sets the `take_over` tag as part of the migration
+- in version `9.0.0` the `take_over` tag will be removed to complete the migration
+
 ### 8.18.1-fb-tolerations
 
 - fixed a bug in the Helm chart that caused tolerations rendering to fail for Filebeat

--- a/charts/elastic-operator/Chart.yaml
+++ b/charts/elastic-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: elastic-operator
-version: 8.18.1-fb-tolerations
+version: 8.18.1-fb-migr-filestream
 appVersion: 8.18.1
 dependencies:
   - name: eck-operator

--- a/charts/elastic-operator/README.md
+++ b/charts/elastic-operator/README.md
@@ -1,6 +1,6 @@
 # elastic-operator
 
-![Version: 8.18.1-fb-tolerations](https://img.shields.io/badge/Version-8.18.1--fb--tolerations-informational?style=flat-square) ![AppVersion: 8.18.1](https://img.shields.io/badge/AppVersion-8.18.1-informational?style=flat-square)
+![Version: 8.18.1-fb-migr-filestream](https://img.shields.io/badge/Version-8.18.1--fb--migr--filestream-informational?style=flat-square) ![AppVersion: 8.18.1](https://img.shields.io/badge/AppVersion-8.18.1-informational?style=flat-square)
 
 Elasticsearch + filebeat + kibana with default common used indexes and Index Lifecycle Management.
 It comes also with a backup functionality. This is the version using ECK-operator to deploy and monitor the stack.
@@ -74,9 +74,14 @@ It comes also with a backup functionality. This is the version using ECK-operato
 | elasticsearch.resources.requests.memory | string | `"8G"` |  |
 | elasticsearch.version | string | `"{{ .Chart.AppVersion }}"` |  |
 | elasticsearch.volumeSize | string | `"200G"` |  |
-| filebeat.autodiscover.providers[0]."hints.default_config".paths[0] | string | `"/var/log/containers/*${data.container.id}.log"` |  |
-| filebeat.autodiscover.providers[0]."hints.default_config".type | string | `"container"` |  |
-| filebeat.autodiscover.providers[0]."hints.enabled" | bool | `true` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.id | string | `"kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}"` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.parsers[0].container | object | `{}` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.paths[0] | string | `"/var/log/containers/*${data.kubernetes.container.id}.log"` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.prospector.scanner."fingerprint.enabled" | bool | `true` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.prospector.scanner.symlinks | bool | `true` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.take_over | bool | `true` |  |
+| filebeat.autodiscover.providers[0].hints.default_config.type | string | `"filestream"` |  |
+| filebeat.autodiscover.providers[0].hints.enabled | bool | `true` |  |
 | filebeat.autodiscover.providers[0].node | string | `"${NODE_NAME}"` |  |
 | filebeat.autodiscover.providers[0].type | string | `"kubernetes"` |  |
 | filebeat.enabled | bool | `true` |  |

--- a/charts/elastic-operator/values.yaml
+++ b/charts/elastic-operator/values.yaml
@@ -148,12 +148,21 @@ filebeat:
   autodiscover:
     providers:
       - type: kubernetes
-        hints.enabled: true
-        hints.default_config:
-          type: container
-          paths:
-            - /var/log/containers/*${data.container.id}.log
         node: ${NODE_NAME}
+        hints:
+          default_config:
+            id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+            parsers:
+            - container: {}
+            paths:
+            - /var/log/containers/*${data.kubernetes.container.id}.log
+            prospector:
+              scanner:
+                fingerprint.enabled: true
+                symlinks: true
+            take_over: true
+            type: filestream
+          enabled: true
   # default processors
   processors:
     - add_kubernetes_metadata: { }


### PR DESCRIPTION
As part of the upgrade path to elastic-stack to version `9.0.0`, this Helm chart version must be installed by customers to avoid Filebeat not being functional after the update. View the CHANGELOG.md for more information.

## Summary
- this Helm chart version adds the `filestream` input and sets the `take_over` tag as part of the migration
- in version `9.0.0` the `take_over` tag will be removed to complete the migration

@krankkkk This update also enables Filebeat to follow symlinks to discover logs and to track files using hashes instead of relying on inodes. If there are any concerns with this approach, we can remove these configurations.

## Testing
- verified the updated chart on the Playground environment
- logs are ingested and no errors are shown in the Filebeat logs
 