### PR TITLE
Promstack uptime dashboard fixes

### DIFF
--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -32,4 +32,4 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 63.1.2
+version: 63.1.3

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -72,17 +72,15 @@ prometheus-stack:
 | global.ingress.paths.prometheus | string | `"/prometheus"` |  |
 | policyException.enabled | bool | `true` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].name | string | `"uptime-monitoring"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].alert | string | `"DecreasingUptime"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].annotations.description | string | `"Uptime of {{ $labels.instance }} less than 95%."` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].alert | string | `"ServiceIsDown"` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].annotations.description | string | `"Uptime of {{ $labels.instance }} is reporting down for 3 consecutive checks."` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].annotations.summary | string | `"{{ $labels.instance }} not reachable"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].expr | string | `"sum by (instance) (avg_over_time(probe_success[5m])) < 0.95\n"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].for | string | `"1m"` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].expr | string | `"sum by (instance) (sum_over_time(probe_success{}[90s])) < 1\n"` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].labels.severity | string | `"high"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].alert | string | `"DecreasingUptime"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].annotations.description | string | `"Uptime of {{ $labels.instance }} less than 50%."` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].alert | string | `"ServiceIsDown"` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].annotations.description | string | `"Uptime of {{ $labels.instance }} is reporting down for 5 consecutive checks."` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].annotations.summary | string | `"{{ $labels.instance }} not reachable"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].expr | string | `"sum by (instance) (avg_over_time(probe_success[5m])) < 0.5\n"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].for | string | `"1m"` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].expr | string | `"sum by (instance) (sum_over_time(probe_success{}[150s])) < 1\n"` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].labels.severity | string | `"critical"` |  |
 | prometheusStack.alertmanager.alertmanagerSpec.externalUrl | string | `"https://{{$.Values.global.ingress.host}}{{$.Values.global.ingress.paths.alertmanager}}"` |  |
 | prometheusStack.alertmanager.alertmanagerSpec.resources.requests.cpu | string | `"5m"` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,6 +1,6 @@
 # prometheus-stack
 
-![Version: 63.1.2](https://img.shields.io/badge/Version-63.1.2-informational?style=flat-square)
+![Version: 63.1.3](https://img.shields.io/badge/Version-63.1.3-informational?style=flat-square)
 
 A complete monitoring/alerting stack with Grafana Prometheus Alertmanager
 

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -76,12 +76,7 @@ prometheus-stack:
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].annotations.description | string | `"Uptime of {{ $labels.instance }} is reporting down for 3 consecutive checks."` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].annotations.summary | string | `"{{ $labels.instance }} not reachable"` |  |
 | prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].expr | string | `"sum by (instance) (sum_over_time(probe_success{}[90s])) < 1\n"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].labels.severity | string | `"high"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].alert | string | `"ServiceIsDown"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].annotations.description | string | `"Uptime of {{ $labels.instance }} is reporting down for 5 consecutive checks."` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].annotations.summary | string | `"{{ $labels.instance }} not reachable"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].expr | string | `"sum by (instance) (sum_over_time(probe_success{}[150s])) < 1\n"` |  |
-| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[1].labels.severity | string | `"critical"` |  |
+| prometheusStack.additionalPrometheusRulesMap.uptime-monitoring.groups[0].rules[0].labels.severity | string | `"critical"` |  |
 | prometheusStack.alertmanager.alertmanagerSpec.externalUrl | string | `"https://{{$.Values.global.ingress.host}}{{$.Values.global.ingress.paths.alertmanager}}"` |  |
 | prometheusStack.alertmanager.alertmanagerSpec.resources.requests.cpu | string | `"5m"` |  |
 | prometheusStack.alertmanager.alertmanagerSpec.resources.requests.memory | string | `"100Mi"` |  |
@@ -102,8 +97,10 @@ prometheus-stack:
 | prometheusStack.alertmanager.config.route.repeat_interval | string | `"12h"` |  |
 | prometheusStack.alertmanager.config.route.routes[0].match.alertname | string | `"Watchdog"` |  |
 | prometheusStack.alertmanager.config.route.routes[0].receiver | string | `"null"` |  |
-| prometheusStack.alertmanager.config.route.routes[1].continue | bool | `true` |  |
+| prometheusStack.alertmanager.config.route.routes[1].group_by[0] | string | `"..."` |  |
+| prometheusStack.alertmanager.config.route.routes[1].matchers[0].severity | string | `"critical"` |  |
 | prometheusStack.alertmanager.config.route.routes[1].receiver | string | `"slack"` |  |
+| prometheusStack.alertmanager.config.route.routes[2].receiver | string | `"slack"` |  |
 | prometheusStack.alertmanager.config.templates[0] | string | `"/etc/alertmanager/config/*.tmpl"` |  |
 | prometheusStack.crds.enabled | bool | `false` |  |
 | prometheusStack.defaultRules.create | bool | `true` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -95,11 +95,14 @@ prometheus-stack:
 | prometheusStack.alertmanager.config.route.group_interval | string | `"5m"` |  |
 | prometheusStack.alertmanager.config.route.group_wait | string | `"30s"` |  |
 | prometheusStack.alertmanager.config.route.repeat_interval | string | `"12h"` |  |
-| prometheusStack.alertmanager.config.route.routes[0].match.alertname | string | `"Watchdog"` |  |
+| prometheusStack.alertmanager.config.route.routes[0].matchers[0] | string | `"alertname=\"Watchdog\""` |  |
 | prometheusStack.alertmanager.config.route.routes[0].receiver | string | `"null"` |  |
 | prometheusStack.alertmanager.config.route.routes[1].group_by[0] | string | `"..."` |  |
-| prometheusStack.alertmanager.config.route.routes[1].matchers[0].severity | string | `"critical"` |  |
+| prometheusStack.alertmanager.config.route.routes[1].group_interval | string | `"1s"` |  |
+| prometheusStack.alertmanager.config.route.routes[1].group_wait | string | `"1s"` |  |
+| prometheusStack.alertmanager.config.route.routes[1].matchers[0] | string | `"severity=\"critical\""` |  |
 | prometheusStack.alertmanager.config.route.routes[1].receiver | string | `"slack"` |  |
+| prometheusStack.alertmanager.config.route.routes[1].repeat_interval | string | `"30m"` |  |
 | prometheusStack.alertmanager.config.route.routes[2].receiver | string | `"slack"` |  |
 | prometheusStack.alertmanager.config.templates[0] | string | `"/etc/alertmanager/config/*.tmpl"` |  |
 | prometheusStack.crds.enabled | bool | `false` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -59,7 +59,7 @@ prometheus-stack:
 | blackboxExporter.serviceMonitor.enabled | bool | `false` |  |
 | blackboxExporter.serviceMonitor.selfMonitor.enabled | bool | `true` |  |
 | blackboxExporter.serviceMonitor.targets | string | `nil` |  |
-| blackboxExporter.strategy.rollingUpdate | object | `{}` |  |
+| blackboxExporter.strategy.rollingUpdate | string | `nil` |  |
 | blackboxExporter.strategy.type | string | `"Recreate"` |  |
 | dashboards.enabled | bool | `true` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -48,7 +48,12 @@ prometheus-stack:
 | blackboxExporter.config.modules.http_2xx.prober | string | `"http"` |  |
 | blackboxExporter.config.modules.http_2xx.timeout | string | `"5s"` |  |
 | blackboxExporter.enabled | bool | `true` |  |
+| blackboxExporter.extraArgs[0] | string | `"--log.level=warn"` |  |
+| blackboxExporter.extraArgs[1] | string | `"--log.format=json"` |  |
 | blackboxExporter.fullnameOverride | string | `"blackbox-exporter"` |  |
+| blackboxExporter.resources.limits.memory | string | `"100Mi"` |  |
+| blackboxExporter.resources.requests.cpu | string | `"100m"` |  |
+| blackboxExporter.resources.requests.memory | string | `"100Mi"` |  |
 | blackboxExporter.secretConfig | bool | `true` |  |
 | blackboxExporter.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | blackboxExporter.serviceMonitor.enabled | bool | `false` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -59,7 +59,7 @@ prometheus-stack:
 | blackboxExporter.serviceMonitor.enabled | bool | `false` |  |
 | blackboxExporter.serviceMonitor.selfMonitor.enabled | bool | `true` |  |
 | blackboxExporter.serviceMonitor.targets | string | `nil` |  |
-| blackboxExporter.strategy | string | `"Recreate"` |  |
+| blackboxExporter.strategy.type | string | `"Recreate"` |  |
 | dashboards.enabled | bool | `true` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.middlewares" | string | `"routing-oidc-forward-auth@kubernetescrd"` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -59,6 +59,7 @@ prometheus-stack:
 | blackboxExporter.serviceMonitor.enabled | bool | `false` |  |
 | blackboxExporter.serviceMonitor.selfMonitor.enabled | bool | `true` |  |
 | blackboxExporter.serviceMonitor.targets | string | `nil` |  |
+| blackboxExporter.strategy.rollingUpdate | object | `{}` |  |
 | blackboxExporter.strategy.type | string | `"Recreate"` |  |
 | dashboards.enabled | bool | `true` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -54,6 +54,7 @@ prometheus-stack:
 | blackboxExporter.serviceMonitor.enabled | bool | `false` |  |
 | blackboxExporter.serviceMonitor.selfMonitor.enabled | bool | `true` |  |
 | blackboxExporter.serviceMonitor.targets | string | `nil` |  |
+| blackboxExporter.strategy | string | `"Recreate"` |  |
 | dashboards.enabled | bool | `true` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.middlewares" | string | `"routing-oidc-forward-auth@kubernetescrd"` |  |

--- a/charts/prometheus-stack/dashboards/blackbox-exporter/custom.json
+++ b/charts/prometheus-stack/dashboards/blackbox-exporter/custom.json
@@ -345,7 +345,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -463,7 +463,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -581,7 +581,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__range:30s] offset -1s\n  )\n)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -701,7 +701,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1s\n  )\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -783,7 +783,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -865,7 +865,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)",
+          "expr": "# Calculate availability rate by instance\n# First calculating the sum of values adjusted by baseline\n# Then dividing by the count of samples in the interval\nsum by (instance) (\n  sum_over_time(\n    # Apply baseline correction (if enabled) and cap at 1.0\n    clamp_max(\n      # Start with raw probe success values\n      probe_success{instance=~\"$instance_selector\"} \n      # Subtract baseline adjustment using vector matching\n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      # Cap at maximum value of 1.0\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)\n/\n# Divide by the count of samples in the time period\nsum by (instance) (\n  count_over_time(\n    clamp_max(\n      probe_success{instance=~\"$instance_selector\"} \n      - on() group_left() min without (pod) ($baseline_correction_toggle * (probe_success{instance=\"$baseline\"} - 1))\n      , 1.0\n    )[$__interval:30s] offset -1d1s\n  )\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -888,7 +888,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -987,6 +987,6 @@
   "timezone": "browser",
   "title": "Blackbox Uptime Monitor",
   "uid": "aejsqqy9db20wc",
-  "version": 110,
+  "version": 115,
   "weekStart": "monday"
 }

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -189,7 +189,7 @@ blackboxExporter:
   # This does result in a brief downtime for the uptime monitoring but reduces the metric aggregation requirements on the dashboard and reduces the chances of inaccurate probe measurements.
   strategy:
     type: Recreate
-    rollingUpdate: {}
+    rollingUpdate: null
   extraArgs:
     [ "--log.level=warn", "--log.format=json" ]
   resources:

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -137,12 +137,15 @@ prometheusStack:
         repeat_interval: 12h
         routes:
           - receiver: 'null'
-            match:
-              alertname: Watchdog
+            matchers:
+              - alertname="Watchdog"
           - receiver: 'slack'
             group_by: [ '...' ]
+            group_wait: 1s
+            group_interval: 1s
+            repeat_interval: 30m
             matchers:
-              - severity: critical
+              - severity="critical"
           - receiver: 'slack'
       receivers:
         - name: 'null'

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -86,22 +86,20 @@ prometheusStack:
       groups:
         - name: uptime-monitoring
           rules:
-            - alert: DecreasingUptime
+            - alert: ServiceIsDown
               annotations:
-                description: 'Uptime of {{ $labels.instance }} less than 95%.'
+                description: 'Uptime of {{ $labels.instance }} is reporting down for 3 consecutive checks.'
                 summary: '{{ $labels.instance }} not reachable'
               expr: >
-                sum by (instance) (avg_over_time(probe_success[5m])) < 0.95
-              for: 1m
+                sum by (instance) (sum_over_time(probe_success{}[90s])) < 1
               labels:
                 severity: high
-            - alert: DecreasingUptime
+            - alert: ServiceIsDown
               annotations:
-                description: 'Uptime of {{ $labels.instance }} less than 50%.'
+                description: 'Uptime of {{ $labels.instance }} is reporting down for 5 consecutive checks.'
                 summary: '{{ $labels.instance }} not reachable'
               expr: >
-                sum by (instance) (avg_over_time(probe_success[5m])) < 0.5
-              for: 1m
+                sum by (instance) (sum_over_time(probe_success{}[150s])) < 1
               labels:
                 severity: critical
 

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -189,6 +189,7 @@ blackboxExporter:
   # This does result in a brief downtime for the uptime monitoring but reduces the metric aggregation requirements on the dashboard and reduces the chances of inaccurate probe measurements.
   strategy:
     type: Recreate
+    rollingUpdate: {}
   extraArgs:
     [ "--log.level=warn", "--log.format=json" ]
   resources:

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -93,14 +93,6 @@ prometheusStack:
               expr: >
                 sum by (instance) (sum_over_time(probe_success{}[90s])) < 1
               labels:
-                severity: high
-            - alert: ServiceIsDown
-              annotations:
-                description: 'Uptime of {{ $labels.instance }} is reporting down for 5 consecutive checks.'
-                summary: '{{ $labels.instance }} not reachable'
-              expr: >
-                sum by (instance) (sum_over_time(probe_success{}[150s])) < 1
-              labels:
                 severity: critical
 
   prometheusOperator:
@@ -148,7 +140,10 @@ prometheusStack:
             match:
               alertname: Watchdog
           - receiver: 'slack'
-            continue: true
+            group_by: [ '...' ]
+            matchers:
+              - severity: critical
+          - receiver: 'slack'
       receivers:
         - name: 'null'
         - name: 'slack'

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -188,6 +188,14 @@ blackboxExporter:
   # strategy: Recreate ensures that we do not have multiple pods reporting on the same endpoint during a rollout.
   # This does result in a brief downtime for the uptime monitoring but reduces the metric aggregation requirements on the dashboard and reduces the chances of inaccurate probe measurements.
   strategy: Recreate
+  extraArgs:
+    [ "--log.level=warn", "--log.format=json" ]
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      memory: 100Mi
   config:
     modules:
       http_2xx:

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -185,6 +185,9 @@ blackboxExporter:
   enabled: true # Chart dependency condition
   fullnameOverride: blackbox-exporter
   secretConfig: true
+  # strategy: Recreate ensures that we do not have multiple pods reporting on the same endpoint during a rollout.
+  # This does result in a brief downtime for the uptime monitoring but reduces the metric aggregation requirements on the dashboard and reduces the chances of inaccurate probe measurements.
+  strategy: Recreate
   config:
     modules:
       http_2xx:

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -187,7 +187,8 @@ blackboxExporter:
   secretConfig: true
   # strategy: Recreate ensures that we do not have multiple pods reporting on the same endpoint during a rollout.
   # This does result in a brief downtime for the uptime monitoring but reduces the metric aggregation requirements on the dashboard and reduces the chances of inaccurate probe measurements.
-  strategy: Recreate
+  strategy:
+    type: Recreate
   extraArgs:
     [ "--log.level=warn", "--log.format=json" ]
   resources:


### PR DESCRIPTION
- Add min aggregation on the custom grafana dashboard to avoid complete dashboard failures if multiple blackbox pods are running
- Change blackbox deployment rollout type to recreate to ensure only a single pod is active during rollout
- Add resource requests/limits to blackbox deployment
- Add logging args for blackbox deployment
- Change alert rule for uptime to trigger if the probe fails for all checks within 90 seconds. with the default 30s scrape interval, this results in 3 consecutive failures
- Change alertmanager grouping behavior of alertmanager so that alerts with label `severity="critical"` are not waiting to get grouped and sent to Slack immediately
- Fix alertmanager deprecated route syntax for label `alertname="Watchdog"`