### PR TITLE
fix(argocd-apps): Changed evaluation if git.password is set to more robust expression

### DIFF
--- a/charts/argocd-apps/Changelog.MD
+++ b/charts/argocd-apps/Changelog.MD
@@ -2,6 +2,10 @@
 
 ## Chart Versions
 
+### 1.0.1
+
+- Fixed a bug that did not allow repositories under ` rojects` in the `values.yaml` to be defined without the key `password`
+
 ### 1.0.0
 
 - Moved code base over from [ArgoCD](https://github.com/iits-consulting/charts/tree/main/charts/argocd) to split usage. ArgoCD chart will take care of the setup and this chart will take care of all content objects being used inside of ArgoCd like Applications. Nex to this, there were no changes made to the code base.

--- a/charts/argocd-apps/Changelog.MD
+++ b/charts/argocd-apps/Changelog.MD
@@ -4,7 +4,7 @@
 
 ### 1.0.1
 
-- Fixed a bug that did not allow repositories under ` rojects` in the `values.yaml` to be defined without the key `password`
+- Fixed a bug that did not allow repositories under `projects` in the `values.yaml` to be defined without the key `password`
 
 ### 1.0.0
 

--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -47,4 +47,4 @@ description: |
   named infrastructure-charts and will install everything from there.
 
 name: argocd-apps
-version: 1.0.0
+version: 1.0.1

--- a/charts/argocd-apps/README.md
+++ b/charts/argocd-apps/README.md
@@ -1,6 +1,6 @@
 # argocd-apps
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
 
 This chart is used to create content objects for ArgoCD like Applications, AppProjects and related K8s secrets for the repo configuration.
 

--- a/charts/argocd-apps/templates/repo-config.yaml
+++ b/charts/argocd-apps/templates/repo-config.yaml
@@ -14,7 +14,7 @@ data:
   password: {{ printf $project.git.password | b64enc }}
   username: {{ printf ($project.git.username | default "ARGOCD_GIT_ACCESS_TOKEN") | b64enc }}
   {{else}}
-    {{- if ne $project.git.repoPrivateKeyBase64Encoded "" }}
+    {{- if $project.git.repoPrivateKeyBase64Encoded }}
   sshPrivateKey: {{ printf $project.git.repoPrivateKeyBase64Encoded }}
     {{- end }}
   {{- end }}

--- a/charts/argocd-apps/templates/repo-config.yaml
+++ b/charts/argocd-apps/templates/repo-config.yaml
@@ -10,7 +10,7 @@ data:
   url: {{ $project.git.repoUrl | b64enc }}
   name: {{ printf $projectName | b64enc }}
   type: {{ printf "git" | b64enc }}
-  {{- if ne $project.git.password  "" }}
+  {{- if $project.git.password }}
   password: {{ printf $project.git.password | b64enc }}
   username: {{ printf ($project.git.username | default "ARGOCD_GIT_ACCESS_TOKEN") | b64enc }}
   {{else}}


### PR DESCRIPTION
The old expression did not cover the case that `password` is completely omitted on a repo config. For example, if a secret with the labels
```
argocd.argoproj.io/secret-type= repository
app.kubernetes.io/part-of=argocd
```
matching the url of the repo was created in the ArgoCD namespace before deploying argocd-apps and the repo config in the values did not contain a password, the changed expression should evaluate to `false`, which it did not. Instead, the templating threw an error, stating that an interface `{}`was provided for `password` in `repo-config.yaml` when it expected a string.
The new expression covers this case but also if `git.password` is actually set to an empty string in the repo config.