### PR TITLE
Update cert-manager-webhook-opentelekomcloud

### DIFF
--- a/charts/cert-manager/Changelog.md
+++ b/charts/cert-manager/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Chart Versions
 
+### 1.17.4-policy-exclusion
+- Update dependency chart cert-manager-webhook-opentelekomcloud to v0.1.5-security-context
+- Adjust policy exclusions to match the new chart
+
 ### 1.17.4
 - Updated Chart & App Version to 1.17.4
 - Made secret creation for OTC DNS clusterIssuer optional based on values

--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v1.17.4
 - name: cert-manager-webhook-opentelekomcloud
   repository: https://iits-consulting.github.io/cert-manager-webhook-opentelekomcloud
-  version: 0.1.4
-digest: sha256:7eba64f50ab66959530c5294507cb96b8881d1034229f0095feed5d83a0fc651
-generated: "2025-09-05T13:32:30.304248+02:00"
+  version: 0.1.5-security-context
+digest: sha256:b3310f4371379734e6bd9f3bdcc53da1a1a5315fa6bda882d83f441cb97ad25f
+generated: "2025-09-15T15:54:48.414894281+02:00"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -5,9 +5,9 @@ dependencies:
     version: v1.17.4
   - name: cert-manager-webhook-opentelekomcloud
     repository: https://iits-consulting.github.io/cert-manager-webhook-opentelekomcloud
-    version: v0.1.4
+    version: v0.1.5-security-context
     condition: clusterIssuers.otcDNS.enabled
 name: cert-manager
 description: Wrapper chart for cert-manager. Deploys a ClusterIssuer resource to bootstrap Let's encrypt cert generation
 appVersion: v1.17.4
-version: 1.17.4
+version: 1.17.4-policy-exclusion

--- a/charts/cert-manager/README.md
+++ b/charts/cert-manager/README.md
@@ -1,6 +1,6 @@
 # cert-manager
 
-![Version: 1.17.4](https://img.shields.io/badge/Version-1.17.4-informational?style=flat-square) ![AppVersion: v1.17.4](https://img.shields.io/badge/AppVersion-v1.17.4-informational?style=flat-square)
+![Version: 1.17.4-policy-exclusion](https://img.shields.io/badge/Version-1.17.4--policy--exclusion-informational?style=flat-square) ![AppVersion: v1.17.4](https://img.shields.io/badge/AppVersion-v1.17.4-informational?style=flat-square)
 
 Wrapper chart for cert-manager. Deploys a ClusterIssuer resource to bootstrap Let's encrypt cert generation
 
@@ -9,7 +9,7 @@ Wrapper chart for cert-manager. Deploys a ClusterIssuer resource to bootstrap Le
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.jetstack.io | cert-manager | v1.17.4 |
-| https://iits-consulting.github.io/cert-manager-webhook-opentelekomcloud | cert-manager-webhook-opentelekomcloud | v0.1.4 |
+| https://iits-consulting.github.io/cert-manager-webhook-opentelekomcloud | cert-manager-webhook-opentelekomcloud | v0.1.5-security-context |
 
 ## Values
 

--- a/charts/cert-manager/templates/policy-exclusion.yaml
+++ b/charts/cert-manager/templates/policy-exclusion.yaml
@@ -9,14 +9,9 @@ metadata:
     "helm.sh/hook-weight": "-5"
 spec:
   exceptions:
-    - policyName: restrict-seccomp-strict
+    - policyName: require-run-as-nonroot
       ruleNames:
-        - check-seccomp-strict
-        - autogen-check-seccomp-strict
-    - policyName: restrict-seccomp
-      ruleNames:
-        - check-seccomp
-        - autogen-check-seccomp
+        - run-as-non-root
     - policyName: enforce-security-context
       ruleNames:
         - add-pod-security-context
@@ -24,8 +19,6 @@ spec:
     any:
       - resources:
           kinds:
-            - Deployment
-            - ReplicaSet
             - Pod
           names:
             - '*cert-manager-webhook-opentelekomcloud*'


### PR DESCRIPTION
- Update dependency chart cert-manager-webhook-opentelekomcloud to v0.1.5-security-context
- Adjust policy exclusions to match the new chart