### PR TITLE
Migration of ArgoCD from Bitnami to official ArgoProject chart

### DIFF
--- a/charts/argocd/Changelog.MD
+++ b/charts/argocd/Changelog.MD
@@ -2,10 +2,15 @@
 
 ## Chart Versions
 
+### 18.0.0
+
+- **Breaking:** Switch from Bitnami to Argo Project implementation of ArgoCD
+- Converted `values.yaml` to ArgoProj requirements (actual configuration was kept as good as possible)
+- Reenabled `policyException` in values
+
 ### 17.0.0
 
 - **Breaking:** Split ArgoCD setup and ArgoCD configuration in two different repositories. To get the same setup as before, add the argocd-apps repo in Version 1.0.0 with the same code as additional chart
-
 
 ### 16.3.3
 
@@ -16,7 +21,7 @@
 - AppVersion update to 2.13.4
 - Added the possibility to set the `enableOCI` flag on the helm-registries
 
- Example of oci Helm Charts:
+Example of oci Helm Charts:
 
 ```hcl
 infrastructure-charts = {

--- a/charts/argocd/Chart.lock
+++ b/charts/argocd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: argo-cd
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.6
-digest: sha256:4fd7a47176f7e56bc5c94b443b8dfb83aba020e7fd0cc446c3787ac1fc42a5ac
-generated: "2025-04-29T13:09:02.157128+02:00"
+  - name: argo-cd
+    repository: https://argoproj.github.io/argo-helm
+    version: 8.0.0
+digest: sha256:6382c8fcc9158852366e1771b8c969fe6fa3e59e2a1942e01e9a9c91a9e8ae19
+generated: "2025-09-15T11:48:17.694840752+02:00"

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -12,7 +12,7 @@ description: |
     name                  = "argocd"
     repository            = "https://charts.iits.tech"
     chart                 = "argocd"
-    version               = "18.1.0"
+    version               = "18.0.0"
     namespace             = "argocd"
     create_namespace      = true
     wait                  = true
@@ -30,4 +30,4 @@ version: 18.0.0
 dependencies:
   - name: argo-cd
     repository: https://argoproj.github.io/argo-helm
-    version: 9.0.0
+    version: 8.0.0

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v2
 description: |
   This chart is used to bootstrap a Kubernetes cluster with `argocd`.
   You can use this chart to deploy `argocd` through tools like `terraform`.
+  Note that this is only deploying the core ArgoCD components. To deploy
+  projects, use the `argocd-apps` chart instead.
 
   Usage example:
 
@@ -10,7 +12,7 @@ description: |
     name                  = "argocd"
     repository            = "https://charts.iits.tech"
     chart                 = "argocd"
-    version               = "17.0.0"
+    version               = "18.1.0"
     namespace             = "argocd"
     create_namespace      = true
     wait                  = true
@@ -23,9 +25,9 @@ description: |
   ```
 
 name: argocd
-appVersion: 2.14.11
-version: 17.0.0
+appVersion: 3.0.0
+version: 18.0.0
 dependencies:
   - name: argo-cd
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 7.3.6
+    repository: https://argoproj.github.io/argo-helm
+    version: 9.0.0

--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -1,9 +1,11 @@
 # argocd
 
-![Version: 17.0.0](https://img.shields.io/badge/Version-17.0.0-informational?style=flat-square) ![AppVersion: 2.14.11](https://img.shields.io/badge/AppVersion-2.14.11-informational?style=flat-square)
+![Version: 18.0.0](https://img.shields.io/badge/Version-18.0.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 This chart is used to bootstrap a Kubernetes cluster with `argocd`.
 You can use this chart to deploy `argocd` through tools like `terraform`.
+Note that this is only deploying the core ArgoCD components. To deploy
+projects, use the `argocd-apps` chart instead.
 
 Usage example:
 
@@ -12,7 +14,7 @@ resource "helm_release" "argocd" {
   name                  = "argocd"
   repository            = "https://charts.iits.tech"
   chart                 = "argocd"
-  version               = "17.0.0"
+  version               = "18.1.0"
   namespace             = "argocd"
   create_namespace      = true
   wait                  = true
@@ -28,43 +30,56 @@ resource "helm_release" "argocd" {
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | argo-cd | 7.3.6 |
+| https://argoproj.github.io/argo-helm | argo-cd | 9.0.0 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| argo-cd.config.rbac."policy.csv" | string | `"g, ARGOCD-ADMIN, role:admin\ng, SYSTEM-ADMINISTRATOR, role:admin\n"` |  |
-| argo-cd.controller.extraEnvVars[0].name | string | `"TZ"` |  |
-| argo-cd.controller.extraEnvVars[0].value | string | `"Europe/Berlin"` |  |
-| argo-cd.controller.kind | string | `"StatefulSet"` |  |
-| argo-cd.controller.logFormat | string | `"json"` |  |
-| argo-cd.controller.replicaCount | int | `2` |  |
-| argo-cd.controller.resourcesPreset | string | `"medium"` |  |
+| argo-cd.configs."oidc.config" | string | `"name: OIDC\nissuer: $argocd-oidc:oidcURL\nclientID: $argocd-oidc:clientID\nclientSecret: $argocd-oidc:clientSecret\nrequestedScopes:\n  - openid\n  - profile\n  - email\n  - groups\nrequestedIDTokenClaims:\n  groups:\n    essential: true\n"` |  |
+| argo-cd.configs."resource.customizations" | string | `"# Ignores .data changes of all secrets with a vaultInjectionChecksum annotation\nargoproj.io/Application:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - '. | select(.metadata.annotations.parametersChecksum) | .spec.source.helm'\n      - '. | select(.metadata.annotations.valueFileChecksum) | .spec.source.helm'\n# Ignores caBundle and template changes of the following resources\nadmissionregistration.k8s.io/MutatingWebhookConfiguration:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .metadata.annotations.template\n      - '.webhooks'\napiextensions.k8s.io/CustomResourceDefinition:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .spec.conversion.webhookClientConfig.caBundle\nadmissionregistration.k8s.io/ValidatingWebhookConfiguration:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .metadata.annotations.template\n      - '.webhooks[]?.clientConfig.caBundle'\n      - '.webhooks'\ncert-manager.io/Certificate:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .spec.duration\nnetworking.k8s.io/Ingress:\n  health.lua: |\n    hs = {}\n    hs.status = \"Healthy\"\n    return hs\n"` |  |
+| argo-cd.configs.rbac."policy.csv" | string | `"g, ARGOCD-ADMIN, role:admin\ng, SYSTEM-ADMINISTRATOR, role:admin\n"` |  |
+| argo-cd.configs.url | string | `"https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"` |  |
+| argo-cd.controller.env[0].name | string | `"TZ"` |  |
+| argo-cd.controller.env[0].value | string | `"Europe/Berlin"` |  |
+| argo-cd.controller.replicas | int | `2` |  |
+| argo-cd.controller.resources.limits.cpu | string | `"750m"` |  |
+| argo-cd.controller.resources.limits.ephemeral-storage | string | `"2Gi"` |  |
+| argo-cd.controller.resources.limits.memory | string | `"768Mi"` |  |
+| argo-cd.controller.resources.requests.cpu | string | `"500m"` |  |
+| argo-cd.controller.resources.requests.ephemeral-storage | string | `"50Mi"` |  |
+| argo-cd.controller.resources.requests.memory | string | `"512Mi"` |  |
 | argo-cd.dex.enabled | bool | `false` |  |
 | argo-cd.fullnameOverride | string | `"argocd"` |  |
+| argo-cd.global.domain | string | `"https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"` |  |
+| argo-cd.global.logging.format | string | `"json"` |  |
+| argo-cd.global.logging.level | string | `"warn"` |  |
 | argo-cd.notifications.enabled | bool | `false` |  |
-| argo-cd.repoServer.containerSecurityContext.seccompProfile.type | string | `"Unconfined"` |  |
-| argo-cd.repoServer.extraEnvVars[0].name | string | `"TZ"` |  |
-| argo-cd.repoServer.extraEnvVars[0].value | string | `"Europe/Berlin"` |  |
-| argo-cd.repoServer.logFormat | string | `"json"` |  |
-| argo-cd.repoServer.replicaCount | int | `2` |  |
-| argo-cd.repoServer.resourcesPreset | string | `"small"` |  |
-| argo-cd.server.config."oidc.config" | string | `"name: OIDC\nissuer: $argocd-oidc:oidcURL\nclientID: $argocd-oidc:clientID\nclientSecret: $argocd-oidc:clientSecret\nrequestedScopes:\n  - openid\n  - profile\n  - email\n  - groups\nrequestedIDTokenClaims:\n  groups:\n    essential: true\n"` |  |
-| argo-cd.server.config."resource.customizations" | string | `"# Ignores .data changes of all secrets with a vaultInjectionChecksum annotation\nargoproj.io/Application:\n ignoreDifferences: |\n    jqPathExpressions:\n      - '. | select(.metadata.annotations.parametersChecksum) | .spec.source.helm'\n      - '. | select(.metadata.annotations.valueFileChecksum) | .spec.source.helm'\n# Ignores caBundle and template changes of the following resources\nadmissionregistration.k8s.io/MutatingWebhookConfiguration:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .metadata.annotations.template\n      - '.webhooks'\napiextensions.k8s.io/CustomResourceDefinition:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .spec.conversion.webhookClientConfig.caBundle\nadmissionregistration.k8s.io/ValidatingWebhookConfiguration:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .metadata.annotations.template\n      - '.webhooks[]?.clientConfig.caBundle'\n      - '.webhooks'\ncert-manager.io/Certificate:\n  ignoreDifferences: |\n    jqPathExpressions:\n      - .spec.duration\nnetworking.k8s.io/Ingress:\n  health.lua: |\n    hs = {}\n    hs.status = \"Healthy\"\n    return hs\n"` |  |
-| argo-cd.server.config.url | string | `"https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"` |  |
-| argo-cd.server.extraEnvVars[0].name | string | `"TZ"` |  |
-| argo-cd.server.extraEnvVars[0].value | string | `"Europe/Berlin"` |  |
-| argo-cd.server.extraEnvVars[1].name | string | `"ARGOCD_SERVER_ROOTPATH"` |  |
-| argo-cd.server.extraEnvVars[1].value | string | `"{{ $path := .Values.server.ingress.path }}{{ if ($path | ne \"/\") }}{{ $path }}{{ end }}"` |  |
+| argo-cd.repoServer.env[0].name | string | `"TZ"` |  |
+| argo-cd.repoServer.env[0].value | string | `"Europe/Berlin"` |  |
+| argo-cd.repoServer.metrics.enabled | bool | `true` |  |
+| argo-cd.repoServer.metrics.serviceMonitor.enabled | bool | `true` |  |
+| argo-cd.repoServer.replicas | int | `2` |  |
+| argo-cd.repoServer.resources.limits.cpu | string | `"750m"` |  |
+| argo-cd.repoServer.resources.limits.ephemeral-storage | string | `"2Gi"` |  |
+| argo-cd.repoServer.resources.limits.memory | string | `"768Mi"` |  |
+| argo-cd.repoServer.resources.requests.cpu | string | `"500m"` |  |
+| argo-cd.repoServer.resources.requests.ephemeral-storage | string | `"50Mi"` |  |
+| argo-cd.repoServer.resources.requests.memory | string | `"512Mi"` |  |
+| argo-cd.server.env[0].name | string | `"TZ"` |  |
+| argo-cd.server.env[0].value | string | `"Europe/Berlin"` |  |
+| argo-cd.server.env[1].name | string | `"ARGOCD_SERVER_ROOTPATH"` |  |
+| argo-cd.server.env[1].value | string | `"{{ $path := .Values.server.ingress.path }}{{ if ($path | ne \"/\") }}{{ $path }}{{ end }}"` |  |
 | argo-cd.server.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |
 | argo-cd.server.ingress.annotations."traefik.ingress.kubernetes.io/router.tls" | string | `"true"` |  |
 | argo-cd.server.ingress.enabled | bool | `true` |  |
 | argo-cd.server.ingress.hostname | string | `"SET_BY_TERRAFORM"` |  |
 | argo-cd.server.ingress.path | string | `"/argocd"` |  |
 | argo-cd.server.insecure | bool | `true` |  |
-| argo-cd.server.logFormat | string | `"json"` |  |
-| argo-cd.server.replicaCount | int | `2` |  |
+| argo-cd.server.metrics.enabled | bool | `true` |  |
+| argo-cd.server.metrics.serviceMonitor.enabled | bool | `true` |  |
+| argo-cd.server.replicas | int | `2` |  |
+| policyException.enabled | bool | `true` |  |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -45,10 +45,10 @@ resource "helm_release" "argocd" {
 | argo-cd.controller.replicas | int | `2` |  |
 | argo-cd.controller.resources.limits.cpu | string | `"750m"` |  |
 | argo-cd.controller.resources.limits.ephemeral-storage | string | `"2Gi"` |  |
-| argo-cd.controller.resources.limits.memory | string | `"768Mi"` |  |
+| argo-cd.controller.resources.limits.memory | string | `"1536Mi"` |  |
 | argo-cd.controller.resources.requests.cpu | string | `"500m"` |  |
 | argo-cd.controller.resources.requests.ephemeral-storage | string | `"50Mi"` |  |
-| argo-cd.controller.resources.requests.memory | string | `"512Mi"` |  |
+| argo-cd.controller.resources.requests.memory | string | `"1024Mi"` |  |
 | argo-cd.dex.enabled | bool | `false` |  |
 | argo-cd.fullnameOverride | string | `"argocd"` |  |
 | argo-cd.global.domain | string | `"{{ .Values.server.ingress.hostname }}"` |  |

--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -14,7 +14,7 @@ resource "helm_release" "argocd" {
   name                  = "argocd"
   repository            = "https://charts.iits.tech"
   chart                 = "argocd"
-  version               = "18.1.0"
+  version               = "18.0.0"
   namespace             = "argocd"
   create_namespace      = true
   wait                  = true
@@ -30,7 +30,7 @@ resource "helm_release" "argocd" {
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://argoproj.github.io/argo-helm | argo-cd | 9.0.0 |
+| https://argoproj.github.io/argo-helm | argo-cd | 8.0.0 |
 
 ## Values
 
@@ -51,7 +51,7 @@ resource "helm_release" "argocd" {
 | argo-cd.controller.resources.requests.memory | string | `"512Mi"` |  |
 | argo-cd.dex.enabled | bool | `false` |  |
 | argo-cd.fullnameOverride | string | `"argocd"` |  |
-| argo-cd.global.domain | string | `"https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"` |  |
+| argo-cd.global.domain | string | `"{{ .Values.server.ingress.hostname }}"` |  |
 | argo-cd.global.logging.format | string | `"json"` |  |
 | argo-cd.global.logging.level | string | `"warn"` |  |
 | argo-cd.notifications.enabled | bool | `false` |  |

--- a/charts/argocd/templates/policy-exception.yaml
+++ b/charts/argocd/templates/policy-exception.yaml
@@ -33,39 +33,5 @@ spec:
           names:
             - argocd-repo-server*
 {{- end }}
-{{- end }}{{ with .Values.policyException }}
-{{ if .enabled }}
-apiVersion: kyverno.io/v2
-kind: PolicyException
-metadata:
-  name: argocd-repo-server
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-spec:
-  exceptions:
-    - policyName: restrict-seccomp-strict
-      ruleNames:
-        - check-seccomp-strict
-        - autogen-check-seccomp-strict
-    - policyName: restrict-seccomp
-      ruleNames:
-        - check-seccomp
-        - autogen-check-seccomp
-    - policyName: enforce-security-context
-      ruleNames:
-        - add-pod-security-context
-  match:
-    any:
-      # Exclude argocd-repo-server, otherwise this error occurs: "getaddrinfo() thread failed to start"
-      - resources:
-          kinds:
-            - Deployment
-            - ReplicaSet
-            - Pod
-          namespaces:
-            - {{ $.Release.Namespace }}
-          names:
-            - argocd-repo-server*
 {{- end }}
-{{- end }}
+

--- a/charts/argocd/templates/policy-exception.yaml
+++ b/charts/argocd/templates/policy-exception.yaml
@@ -33,4 +33,39 @@ spec:
           names:
             - argocd-repo-server*
 {{- end }}
+{{- end }}{{ with .Values.policyException }}
+{{ if .enabled }}
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: argocd-repo-server
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  exceptions:
+    - policyName: restrict-seccomp-strict
+      ruleNames:
+        - check-seccomp-strict
+        - autogen-check-seccomp-strict
+    - policyName: restrict-seccomp
+      ruleNames:
+        - check-seccomp
+        - autogen-check-seccomp
+    - policyName: enforce-security-context
+      ruleNames:
+        - add-pod-security-context
+  match:
+    any:
+      # Exclude argocd-repo-server, otherwise this error occurs: "getaddrinfo() thread failed to start"
+      - resources:
+          kinds:
+            - Deployment
+            - ReplicaSet
+            - Pod
+          namespaces:
+            - {{ $.Release.Namespace }}
+          names:
+            - argocd-repo-server*
+{{- end }}
 {{- end }}

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -1,30 +1,62 @@
 argo-cd:
   fullnameOverride: "argocd"
 
+  global:
+    logging:
+      format: "json"
+      level: "warn"
+    domain: "https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"
+
   controller:
-    kind: StatefulSet
-    replicaCount: 2
-    extraEnvVars:
+    replicas: 2
+    env:
       - name: "TZ"
         value: "Europe/Berlin"
-    logFormat: "json"
-    resourcesPreset: "medium"
+    # resources equivalent to Bitnami setting "small"
+    # see https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+        ephemeral-storage: 50Mi
+      limits:
+        cpu: 750m
+        memory: 768Mi
+        ephemeral-storage: 2Gi
+
   dex:
     enabled: false
+
   notifications:
     enabled: false
+
   repoServer:
-    replicaCount: 2
-    extraEnvVars:
+    replicas: 2
+    env:
       - name: "TZ"
         value: "Europe/Berlin"
-    logFormat: "json"
-    resourcesPreset: "small"
-    containerSecurityContext:
-      seccompProfile:
-        type: Unconfined
+    # resources equivalent to Bitnami setting "small"
+    # see https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+        ephemeral-storage: 50Mi
+      limits:
+        cpu: 750m
+        memory: 768Mi
+        ephemeral-storage: 2Gi
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+
   server:
-    replicaCount: 2
+    replicas: 2
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
     ingress:
       enabled: true
       hostname: "SET_BY_TERRAFORM"
@@ -32,7 +64,7 @@ argo-cd:
         traefik.ingress.kubernetes.io/router.entrypoints: websecure
         traefik.ingress.kubernetes.io/router.tls: "true"
       path: "/argocd"
-    extraEnvVars:
+    env:
       - name: "TZ"
         value: "Europe/Berlin"
 
@@ -42,62 +74,60 @@ argo-cd:
       - name: "ARGOCD_SERVER_ROOTPATH"
         # If we are serving on the root '/' this variable needs to be either non-existent or empty for the argo-server to respond properly.
         # Relevant if you want to serve argo on a dedicated sub-domain i.e. argo.example.com
-        value: "{{ $path := .Values.server.ingress.path }}{{ if ($path | ne \"/\") }}{{ $path }}{{ end }}"
+        value: '{{ $path := .Values.server.ingress.path }}{{ if ($path | ne "/") }}{{ $path }}{{ end }}'
 
-    logFormat: json
-    insecure: true
+    insecure: true #We terminate https at our router (traefik)
 
-    config:
-      url: "https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"
+  configs:
+    url: "https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"
 
-      oidc.config: |
-        name: OIDC
-        issuer: $argocd-oidc:oidcURL
-        clientID: $argocd-oidc:clientID
-        clientSecret: $argocd-oidc:clientSecret
-        requestedScopes:
-          - openid
-          - profile
-          - email
-          - groups
-        requestedIDTokenClaims:
-          groups:
-            essential: true
+    oidc.config: |
+      name: OIDC
+      issuer: $argocd-oidc:oidcURL
+      clientID: $argocd-oidc:clientID
+      clientSecret: $argocd-oidc:clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - groups
+      requestedIDTokenClaims:
+        groups:
+          essential: true
 
-      resource.customizations: |
-        # Ignores .data changes of all secrets with a vaultInjectionChecksum annotation
-        argoproj.io/Application:
-         ignoreDifferences: |
-            jqPathExpressions:
-              - '. | select(.metadata.annotations.parametersChecksum) | .spec.source.helm'
-              - '. | select(.metadata.annotations.valueFileChecksum) | .spec.source.helm'
-        # Ignores caBundle and template changes of the following resources
-        admissionregistration.k8s.io/MutatingWebhookConfiguration:
-          ignoreDifferences: |
-            jqPathExpressions:
-              - .metadata.annotations.template
-              - '.webhooks'
-        apiextensions.k8s.io/CustomResourceDefinition:
-          ignoreDifferences: |
-            jqPathExpressions:
-              - .spec.conversion.webhookClientConfig.caBundle
-        admissionregistration.k8s.io/ValidatingWebhookConfiguration:
-          ignoreDifferences: |
-            jqPathExpressions:
-              - .metadata.annotations.template
-              - '.webhooks[]?.clientConfig.caBundle'
-              - '.webhooks'
-        cert-manager.io/Certificate:
-          ignoreDifferences: |
-            jqPathExpressions:
-              - .spec.duration
-        networking.k8s.io/Ingress:
-          health.lua: |
-            hs = {}
-            hs.status = "Healthy"
-            return hs
+    resource.customizations: |
+      # Ignores .data changes of all secrets with a vaultInjectionChecksum annotation
+      argoproj.io/Application:
+        ignoreDifferences: |
+          jqPathExpressions:
+            - '. | select(.metadata.annotations.parametersChecksum) | .spec.source.helm'
+            - '. | select(.metadata.annotations.valueFileChecksum) | .spec.source.helm'
+      # Ignores caBundle and template changes of the following resources
+      admissionregistration.k8s.io/MutatingWebhookConfiguration:
+        ignoreDifferences: |
+          jqPathExpressions:
+            - .metadata.annotations.template
+            - '.webhooks'
+      apiextensions.k8s.io/CustomResourceDefinition:
+        ignoreDifferences: |
+          jqPathExpressions:
+            - .spec.conversion.webhookClientConfig.caBundle
+      admissionregistration.k8s.io/ValidatingWebhookConfiguration:
+        ignoreDifferences: |
+          jqPathExpressions:
+            - .metadata.annotations.template
+            - '.webhooks[]?.clientConfig.caBundle'
+            - '.webhooks'
+      cert-manager.io/Certificate:
+        ignoreDifferences: |
+          jqPathExpressions:
+            - .spec.duration
+      networking.k8s.io/Ingress:
+        health.lua: |
+          hs = {}
+          hs.status = "Healthy"
+          return hs
 
-  config:
     rbac:
       policy.csv: |
         g, ARGOCD-ADMIN, role:admin
@@ -105,3 +135,7 @@ argo-cd:
 
 # Please use argocd-secret chart instead if you are using keycloak deployed in the same stage to avoid cyclic dependencies.
 #    secret:
+
+# Kyverno Policy Exception
+policyException:
+  enabled: true

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -5,7 +5,7 @@ argo-cd:
     logging:
       format: "json"
       level: "warn"
-    domain: "https://{{ .Values.server.ingress.hostname }}{{ .Values.server.ingress.path }}"
+    domain: "{{ .Values.server.ingress.hostname }}"
 
   controller:
     replicas: 2

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -74,7 +74,7 @@ argo-cd:
       - name: "ARGOCD_SERVER_ROOTPATH"
         # If we are serving on the root '/' this variable needs to be either non-existent or empty for the argo-server to respond properly.
         # Relevant if you want to serve argo on a dedicated sub-domain i.e. argo.example.com
-        value: '{{ $path := .Values.server.ingress.path }}{{ if ($path | ne "/") }}{{ $path }}{{ end }}'
+        value: "{{ $path := .Values.server.ingress.path }}{{ if ($path | ne \"/\") }}{{ $path }}{{ end }}"
 
     insecure: true #We terminate https at our router (traefik)
 

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -12,16 +12,16 @@ argo-cd:
     env:
       - name: "TZ"
         value: "Europe/Berlin"
-    # resources equivalent to Bitnami setting "small"
+    # resources equivalent to Bitnami setting "medium"
     # see https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
     resources:
       requests:
         cpu: 500m
-        memory: 512Mi
+        memory: 1024Mi
         ephemeral-storage: 50Mi
       limits:
         cpu: 750m
-        memory: 768Mi
+        memory: 1536Mi
         ephemeral-storage: 2Gi
 
   dex:
@@ -74,7 +74,7 @@ argo-cd:
       - name: "ARGOCD_SERVER_ROOTPATH"
         # If we are serving on the root '/' this variable needs to be either non-existent or empty for the argo-server to respond properly.
         # Relevant if you want to serve argo on a dedicated sub-domain i.e. argo.example.com
-        value: "{{ $path := .Values.server.ingress.path }}{{ if ($path | ne \"/\") }}{{ $path }}{{ end }}"
+        value: '{{ $path := .Values.server.ingress.path }}{{ if ($path | ne "/") }}{{ $path }}{{ end }}'
 
     insecure: true #We terminate https at our router (traefik)
 


### PR DESCRIPTION
The Bitnami ArgoCD chart automatically deploys Redis with persistence enabled, which would require storage classes on the cluster. At the time of bootstrapping in the new setup these are not available yet. This behaviour cannot be turned of through chart configuration, it is either Redis with persistence or your own Redis. It makes sense to use this opportunity to migrate away from Bitnami, as this behaviour is not present in the official ArgoCD chart by the Argo Project.

Tried to keep the functional outcome of the deployed ArgoCD as close as possible to the outcome with the Bitnami chart. Had to refactor the `values.yaml` for this a bit.

Also enabled the Kyverno `policyException` again after accidentally removing it.