### PR TITLE
feat(Kyverno): Allow use of existing Docker pull secrets (updated main)

### DIFF
--- a/charts/kyverno/Changelog.md
+++ b/charts/kyverno/Changelog.md
@@ -2,6 +2,11 @@
 
 ## Chart Versions
 
+### 3.0.0
+
+- **Breaking** Set default of `autoInjectDockerPullSecrets.enabled` to false
+- Added feature to use existing imagePullSecrets in release namespace
+
 ### 2.5.0
 
 - Simplified mutating policy for security context enforcement

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -18,5 +18,5 @@ dependencies:
     version: 3.1.3
     condition: policy-reporter.install
 type: application
-version: 2.5.0
+version: 3.0.0
 appVersion: 1.13.4

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -1,6 +1,6 @@
 # kyverno
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.4](https://img.shields.io/badge/AppVersion-1.13.4-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.4](https://img.shields.io/badge/AppVersion-1.13.4-informational?style=flat-square)
 
 This chart wraps the upstream `kyverno` and `kyverno-policies` chart and adds a few useful policies:
   - Verify all images are signed with cosign
@@ -20,8 +20,9 @@ This chart wraps the upstream `kyverno` and `kyverno-policies` chart and adds a 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| autoInjectDockerPullSecrets.enabled | bool | `true` |  |
-| autoInjectDockerPullSecrets.secrets | string | `nil` |  |
+| autoInjectDockerPullSecrets.enabled | bool | `false` |  |
+| autoInjectDockerPullSecrets.existingSecretRef | list | `[]` |  |
+| autoInjectDockerPullSecrets.secrets | object | `{}` |  |
 | disallowEmptyIngressHost.enabled | bool | `true` |  |
 | disallowEmptyIngressHost.excludeNamespaces | string | `nil` |  |
 | disallowUnsignedImages.enabled | bool | `false` | Enable or disable the policy globally |

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{- define "allPullSecretRefs" -}}
+  {{- /* Catch if both pull secret entries in values.yaml are empty*/ -}}
+  {{- if and (not .Values.autoInjectDockerPullSecrets.existingSecretRef) (not .Values.autoInjectDockerPullSecrets.secrets) }}
+    {{- $existing := ""}}
+  {{- else }}
+    {{- /* Grab the existing secret references as they are */ -}}
+    {{- $existing := list }}
+      {{- range $existingElement := .Values.autoInjectDockerPullSecrets.existingSecretRef | default dict }}
+        {{- $existing = append $existing (printf $existingElement.name)  }}
+      {{- end }}
+
+    {{- /* Iterate over the keys of the `secrets` map */ -}}
+    {{- range $key := (keys .Values.autoInjectDockerPullSecrets.secrets | default (list)) -}}
+      {{- /* Append the prefixed key to the list */ -}}
+      {{- $existing = append $existing (printf "pull-secret-%s" $key) -}}
+    {{- end -}}
+
+    {{- /* Comma separate the list output so it can be parsed properly */ -}}
+    {{- join "," $existing -}}
+  {{- end -}}
+{{- end -}}
+

--- a/charts/kyverno/templates/policies/add-image-pull-secrets.yaml
+++ b/charts/kyverno/templates/policies/add-image-pull-secrets.yaml
@@ -1,3 +1,4 @@
+{{- $pullSecretNames := include "allPullSecretRefs" . | split "," }}
 {{- with .Values.autoInjectDockerPullSecrets }}
 {{- if .enabled }}
 apiVersion: kyverno.io/v1
@@ -35,10 +36,11 @@ spec:
               clusterpolicies.kyverno.io/add-image-pull-secret: "Added pullSecrets"
           spec:
             imagePullSecrets:
-{{- range $registryName,$registryValues := .secrets }}
-              - name: pull-secret-{{ $registryName }}
+{{- range $pullSecretName := $pullSecretNames }}
+              - name: {{ $pullSecretName }}
 {{- end }}
 ---
+# This section creates new secrets from the specifications in the chart values
 {{- range $registryName,$registryValues := .secrets }}
 {{ with $dockerconfigjson := printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $registryValues.registryUrl (printf "%s:%s" $registryValues.username $registryValues.password | b64enc) | b64enc }}
 apiVersion: kyverno.io/v1
@@ -76,8 +78,34 @@ metadata:
   name: pull-secret-{{ $registryName }}
 data:
   .dockerconfigjson: {{ $dockerconfigjson }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 ---
-{{- end }}
-{{- end }}
-{{- end }}
+# This section creates the policies to clone from the existing secrets
+{{- range $existingSecretRef := .Values.autoInjectDockerPullSecrets.existingSecretRef }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: auto-create-docker-{{ $existingSecretRef.name }}
+spec:
+  rules:
+    - name: auto-create-docker-{{ $existingSecretRef.name }}
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      generate:
+        generateExisting: true
+        synchronize: true
+        apiVersion: v1
+        kind: Secret
+        name: {{ $existingSecretRef.name }}
+        # generate the resource in the new namespace
+        namespace: '{{"{{request.object.metadata.name}}"}}'
+        clone:
+          name: {{ $existingSecretRef.name }}
+          namespace: {{ $existingSecretRef.namespace }}
 {{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -336,17 +336,30 @@ enforceSecurityContext:
   # - my-namespace
 
 autoInjectDockerPullSecrets:
-  enabled: true
+  enabled: false
 
-  secrets:
-#    gitlab:
-#      username: "access_token"
-#      password: "token or password"
-#      registryUrl: "registry.gitlab.com"
-#    github:
-#      username: "token_name"
-#      password: "token or password"
-#      registryUrl: "myregistry"
+  # You can specify existing secrets of type "kubernetes.io/dockerconfigjson" under "existingSecretRef" to
+  # clone and use instead of letting Kyverno create these secrets from the chart values. Note that the
+  # secrets to copy must contain valid ".dockerconfigjson" data. Additionally, the existing secrets to
+  # be used must be specified under "existingImagePullSecrets" in the values.yaml.
+  # It is possible to use both existing secrets and have Kyverno create new secrets from the chart at the
+  # same time. For this, specify existing secrets under "existingSecretRef" and the ones to create under
+  # "secrets" as displayed in the examples.
+  existingSecretRef: []
+  # - name: pull-secret-dockerhub
+  #   namespace: kyverno
+  # - name: pull-secret-mycustomregistry
+  #   namespace: mycustomnamespace
+
+  secrets: {}
+  #  gitlab:
+  #    username: "access_token"
+  #    password: "token or password"
+  #    registryUrl: "registry.gitlab.com"
+  #  github:
+  #    username: "token_name"
+  #    password: "token or password"
+  #    registryUrl: "myregistry"
 
 disallowEmptyIngressHost:
   enabled: true


### PR DESCRIPTION
New merge request on repo branch instead of fork. Fork got too fiddly.
Basically the same changes as #181 with two additions to `charts/kyverno/values.yaml`: 
- line 348: added `[]`:
```
existingSecretRef: []
```
- line 354 added ' {}':
```
secrets: {}
```