### PR TITLE
Add PasswordGenerators to common chart

### DIFF
--- a/charts/common/.helmignore
+++ b/charts/common/.helmignore
@@ -1,0 +1,2 @@
+tests/
+.helmignore

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
-appVersion: v0.0.1
-version: 0.0.1
+appVersion: v0.0.2
+version: 0.0.2

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
-appVersion: v0.0.2
-version: 0.0.2
+appVersion: v0.1.0
+version: 0.1.0

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![AppVersion: v0.0.2](https://img.shields.io/badge/AppVersion-v0.0.2-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
 
@@ -9,6 +9,7 @@ A Library Helm Chart for grouping common logic between charts. This chart is not
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalSecret.enabled | bool | `false` |  |
+| externalSecret.generators | object | `{"passwords":{}}` | Creates Password generator CRDs. Used with PushSecrets that have generatorRef selectors. |
 | externalSecret.pull | object | `{"enabled":false,"secrets":{},"spec":{"conversionStrategy":"Default","creationPolicy":"Owner","decodingStrategy":"None","deletionPolicy":"Delete","metadataPolicy":"None","refreshInterval":"1m"}}` | Create ExternalSecret resources. It describes what data should be fetched, how the data should be transformed and saved as a Kind=Secret. |
 | externalSecret.push | object | `{"enabled":false,"secrets":{},"spec":{"conversionStrategy":"Default","decodingStrategy":"None","deletionPolicy":"Delete","metadataPolicy":"None","refreshInterval":"1h","secretStores":[],"updatePolicy":"IfNotExists"}}` | Creates a PushSecret resource. It describes what data should be pushed to the SecretStore. This will be created also when pull is set to false. |
 | externalSecret.secretStore.kind | string | `"ClusterSecretStore"` |  |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![AppVersion: v0.0.2](https://img.shields.io/badge/AppVersion-v0.0.2-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -9,7 +9,7 @@ A Library Helm Chart for grouping common logic between charts. This chart is not
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalSecret.enabled | bool | `false` |  |
-| externalSecret.generators | object | `{"passwords":{}}` | Creates Password generator CRDs. Used with PushSecrets that have generatorRef selectors. |
+| externalSecret.generators | object | `{"enabled":false,"passwords":{}}` | Creates Password generator CRDs. Used with PushSecrets that have generatorRef selectors. |
 | externalSecret.pull | object | `{"enabled":false,"secrets":{},"spec":{"conversionStrategy":"Default","creationPolicy":"Owner","decodingStrategy":"None","deletionPolicy":"Delete","metadataPolicy":"None","refreshInterval":"1m"}}` | Create ExternalSecret resources. It describes what data should be fetched, how the data should be transformed and saved as a Kind=Secret. |
 | externalSecret.push | object | `{"enabled":false,"secrets":{},"spec":{"conversionStrategy":"Default","decodingStrategy":"None","deletionPolicy":"Delete","metadataPolicy":"None","refreshInterval":"1h","secretStores":[],"updatePolicy":"IfNotExists"}}` | Creates a PushSecret resource. It describes what data should be pushed to the SecretStore. This will be created also when pull is set to false. |
 | externalSecret.secretStore.kind | string | `"ClusterSecretStore"` |  |

--- a/charts/common/templates/external-secret.yaml
+++ b/charts/common/templates/external-secret.yaml
@@ -17,6 +17,12 @@ spec:
   secretStoreRef:
     kind: {{ $.Values.externalSecret.secretStore.kind }}
     name: {{ $.Values.externalSecret.secretStore.name }}
+{{- if $secretConfig.generatorRef }}
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          {{- $secretConfig.generatorRef | toYaml | nindent 10 }}
+{{- else }}
   data:
   {{- range $secretConfig.keys }}
     - secretKey: {{ .name | quote }}
@@ -27,6 +33,7 @@ spec:
         decodingStrategy: {{ $secretConfig.decodingStrategy | default $spec.decodingStrategy }}
         metadataPolicy: {{ $secretConfig.metadataPolicy | default $spec.metadataPolicy }}
   {{- end }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/common/templates/external-secret.yaml
+++ b/charts/common/templates/external-secret.yaml
@@ -6,12 +6,14 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
 spec:
   refreshInterval: {{ $spec.refreshInterval }}
   target:
-    name: {{ $secretName }}
-    creationPolicy: {{ $spec.creationPolicy }}
-    deletionPolicy: {{ $spec.deletionPolicy }}
+    name: {{ $secretConfig.targetName | default $secretName }}
+    creationPolicy: {{ $secretConfig.creationPolicy | default $spec.creationPolicy }}
+    deletionPolicy: {{ $secretConfig.deletionPolicy | default $spec.deletionPolicy }}
   secretStoreRef:
     kind: {{ $.Values.externalSecret.secretStore.kind }}
     name: {{ $.Values.externalSecret.secretStore.name }}

--- a/charts/common/templates/password-generator.yaml
+++ b/charts/common/templates/password-generator.yaml
@@ -1,5 +1,5 @@
 {{- with .Values.externalSecret }}
-{{- if and .enabled .generators.passwords }}
+{{- if and .enabled .generators.enabled .generators.passwords }}
 {{- range $name, $config := .generators.passwords }}
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password

--- a/charts/common/templates/password-generator.yaml
+++ b/charts/common/templates/password-generator.yaml
@@ -1,0 +1,15 @@
+{{- with .Values.externalSecret }}
+{{- if and .enabled .generators.passwords }}
+{{- range $name, $config := .generators.passwords }}
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: {{ $name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+spec:
+  {{- $config.spec | toYaml | nindent 2 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/push-secret.yaml
+++ b/charts/common/templates/push-secret.yaml
@@ -18,9 +18,9 @@ spec:
     secret:
       name: {{ $secretConfig.sourceSecretName | default $secretName }}
 {{- end }}
-  refreshInterval: {{ $spec.refreshInterval }}
-  deletionPolicy: {{ $spec.deletionPolicy }}
-  updatePolicy: {{ $spec.updatePolicy }}
+  refreshInterval: {{ $secretConfig.refreshInterval | default $spec.refreshInterval }}
+  deletionPolicy: {{ $secretConfig.deletionPolicy | default $spec.deletionPolicy }}
+  updatePolicy: {{ $secretConfig.updatePolicy | default $spec.updatePolicy }}
   secretStoreRefs:
   {{- if $spec.secretStores }}
     {{- range $secretStore := $spec.secretStores }}

--- a/charts/common/templates/push-secret.yaml
+++ b/charts/common/templates/push-secret.yaml
@@ -6,10 +6,18 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: {{ $secretName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "12"
 spec:
+{{- if $secretConfig.generatorRef }}
+  selector:
+    generatorRef:
+      {{- $secretConfig.generatorRef | toYaml | nindent 6 }}
+{{- else }}
   selector:
     secret:
-      name: {{ $secretName }}
+      name: {{ $secretConfig.sourceSecretName | default $secretName }}
+{{- end }}
   refreshInterval: {{ $spec.refreshInterval }}
   deletionPolicy: {{ $spec.deletionPolicy }}
   updatePolicy: {{ $spec.updatePolicy }}
@@ -21,18 +29,16 @@ spec:
   {{- else }}
     - kind: {{ $.Values.externalSecret.secretStore.kind }}
       name: {{ $.Values.externalSecret.secretStore.name }}
-  {{- end }} 
-  data:
-  {{- range $secretConfig.keys }}
-  - match:
-      secretKey: {{ .name | quote }}
-      remoteRef:
-        remoteKey: {{ required "Path to push secret is required" $secretConfig.path | quote }}
-        property: {{ .remoteKey | default .name | quote }}
-        conversionStrategy: {{ $secretConfig.conversionStrategy | default $spec.conversionStrategy }}
-        decodingStrategy: {{ $secretConfig.decodingStrategy | default $spec.decodingStrategy }}
-        metadataPolicy: {{ $secretConfig.metadataPolicy | default $spec.metadataPolicy }}
   {{- end }}
+  data:
+      {{- range $secretConfig.keys }}
+    - conversionStrategy: None
+      match:
+        secretKey: {{ .name | quote }}
+        remoteRef:
+          remoteKey: {{ required "Path to push secret is required" $secretConfig.path | quote }}
+          property: {{ .remoteKey | default .name | quote }}
+      {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/common/tests/external-secret_test.yaml
+++ b/charts/common/tests/external-secret_test.yaml
@@ -1,0 +1,120 @@
+suite: ExternalSecret
+templates:
+  - external-secret.yaml
+
+tests:
+  - it: should create an ExternalSecret with two keys
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          path: "test/path"
+          keys:
+            - name: accessKey
+              remoteKey: access_key
+            - name: secretKey
+              remoteKey: secret_key
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: test
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "13"
+      - equal:
+          path: spec.target.name
+          value: test
+      - equal:
+          path: spec.data
+          value:
+            - secretKey: "accessKey"
+              remoteRef:
+                key: "test/path"
+                property: "access_key"
+                conversionStrategy: Default
+                decodingStrategy: None
+                metadataPolicy: None
+            - secretKey: "secretKey"
+              remoteRef:
+                key: "test/path"
+                property: "secret_key"
+                conversionStrategy: Default
+                decodingStrategy: None
+                metadataPolicy: None
+
+  - it: should use targetName override when specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        my-external-secret:
+          targetName: my-actual-secret
+          path: "test/path"
+          keys:
+            - name: password
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-external-secret
+      - equal:
+          path: spec.target.name
+          value: my-actual-secret
+
+  - it: should allow per-secret creationPolicy and deletionPolicy overrides
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        merge-secret:
+          targetName: existing-secret
+          creationPolicy: Merge
+          deletionPolicy: Retain
+          path: "test/path"
+          keys:
+            - name: password
+    asserts:
+      - equal:
+          path: spec.target.creationPolicy
+          value: Merge
+      - equal:
+          path: spec.target.deletionPolicy
+          value: Retain
+
+  - it: should use generatorRef via dataFrom when specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        generated-secret:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: Password
+            name: my-password-gen
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.dataFrom[0].sourceRef.generatorRef.kind
+          value: Password
+      - equal:
+          path: spec.dataFrom[0].sourceRef.generatorRef.name
+          value: my-password-gen
+      - isNull:
+          path: spec.data
+
+  - it: should use remoteKey default to name when remoteKey not specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          path: "test/path"
+          keys:
+            - name: myKey
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: "myKey"

--- a/charts/common/tests/no-external-secret_test.yaml
+++ b/charts/common/tests/no-external-secret_test.yaml
@@ -1,0 +1,30 @@
+suite: ExternalSecret negative cases
+templates:
+  - external-secret.yaml
+
+tests:
+  - it: should not create ExternalSecret when pull is disabled
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        test:
+          path: "test"
+          keys:
+            - name: accessKey
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create ExternalSecret when externalSecret is disabled
+    set:
+      externalSecret.enabled: false
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          path: "test"
+          keys:
+            - name: accessKey
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/common/tests/no-push-secret_test.yaml
+++ b/charts/common/tests/no-push-secret_test.yaml
@@ -1,0 +1,30 @@
+suite: PushSecret negative cases
+templates:
+  - push-secret.yaml
+
+tests:
+  - it: should not create PushSecret when push is disabled
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          path: "test"
+          keys:
+            - name: accessKey
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create PushSecret when externalSecret is disabled
+    set:
+      externalSecret.enabled: false
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        test:
+          path: "test"
+          keys:
+            - name: accessKey
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/common/tests/password-generator_test.yaml
+++ b/charts/common/tests/password-generator_test.yaml
@@ -1,0 +1,75 @@
+suite: Password Generator
+templates:
+  - password-generator.yaml
+
+tests:
+  - it: should create a Password generator
+    set:
+      externalSecret.enabled: true
+      externalSecret.generators.enabled: true
+      externalSecret.generators.passwords:
+        my-password:
+          spec:
+            length: 32
+            digits: 8
+            symbols: 0
+    asserts:
+      - isKind:
+          of: Password
+      - isAPIVersion:
+          of: generators.external-secrets.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: my-password
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "11"
+      - equal:
+          path: spec
+          value:
+            length: 32
+            digits: 8
+            symbols: 0
+
+  - it: should create multiple Password generators
+    set:
+      externalSecret.enabled: true
+      externalSecret.generators.enabled: true
+      externalSecret.generators.passwords:
+        gen-one:
+          spec:
+            length: 16
+            digits: 4
+            symbols: 0
+        gen-two:
+          spec:
+            length: 64
+            digits: 16
+            symbols: 4
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should not create generators when generators.enabled is false
+    set:
+      externalSecret.enabled: true
+      externalSecret.generators.enabled: false
+      externalSecret.generators.passwords:
+        my-password:
+          spec:
+            length: 32
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create generators when externalSecret is disabled
+    set:
+      externalSecret.enabled: false
+      externalSecret.generators.enabled: true
+      externalSecret.generators.passwords:
+        my-password:
+          spec:
+            length: 32
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/common/tests/push-secret_test.yaml
+++ b/charts/common/tests/push-secret_test.yaml
@@ -1,0 +1,125 @@
+suite: PushSecret
+templates:
+  - push-secret.yaml
+
+tests:
+  - it: should create a PushSecret with two keys
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        test:
+          path: "test/path"
+          keys:
+            - name: accessKey
+              remoteKey: access_key
+            - name: secretKey
+              remoteKey: secret_key
+    asserts:
+      - isKind:
+          of: PushSecret
+      - equal:
+          path: metadata.name
+          value: test
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "12"
+      - equal:
+          path: spec.selector.secret.name
+          value: test
+      - equal:
+          path: spec.data
+          value:
+            - conversionStrategy: None
+              match:
+                secretKey: "accessKey"
+                remoteRef:
+                  remoteKey: "test/path"
+                  property: "access_key"
+            - conversionStrategy: None
+              match:
+                secretKey: "secretKey"
+                remoteRef:
+                  remoteKey: "test/path"
+                  property: "secret_key"
+
+  - it: should use generatorRef selector when specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        gen-push:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: Password
+            name: my-gen
+          path: "test/path"
+          keys:
+            - name: password
+    asserts:
+      - equal:
+          path: spec.selector.generatorRef.kind
+          value: Password
+      - equal:
+          path: spec.selector.generatorRef.name
+          value: my-gen
+      - isNull:
+          path: spec.selector.secret
+
+  - it: should use sourceSecretName override when specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        my-push:
+          sourceSecretName: actual-k8s-secret
+          path: "test/path"
+          keys:
+            - name: username
+    asserts:
+      - equal:
+          path: spec.selector.secret.name
+          value: actual-k8s-secret
+
+  - it: should allow per-secret refreshInterval, deletionPolicy, updatePolicy overrides
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        override-push:
+          refreshInterval: 30m
+          deletionPolicy: None
+          updatePolicy: Replace
+          path: "test/path"
+          keys:
+            - name: key1
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: 30m
+      - equal:
+          path: spec.deletionPolicy
+          value: None
+      - equal:
+          path: spec.updatePolicy
+          value: Replace
+
+  - it: should fall back to spec-level defaults when no per-secret overrides
+    set:
+      externalSecret.enabled: true
+      externalSecret.push.enabled: true
+      externalSecret.push.secrets:
+        default-push:
+          path: "test/path"
+          keys:
+            - name: key1
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.deletionPolicy
+          value: Delete
+      - equal:
+          path: spec.updatePolicy
+          value: IfNotExists

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -8,6 +8,7 @@ externalSecret:
   
   # -- Creates Password generator CRDs. Used with PushSecrets that have generatorRef selectors.
   generators:
+    enabled: false
     passwords: {}
       # <name>:
       #   spec:
@@ -55,6 +56,9 @@ externalSecret:
       #     apiVersion: generators.external-secrets.io/v1alpha1
       #     kind: Password
       #     name: "generator-name"
+      #   refreshInterval: 1h # optional, overrides spec-level refreshInterval
+      #   deletionPolicy: Delete # optional, overrides spec-level deletionPolicy
+      #   updatePolicy: IfNotExists # optional, overrides spec-level updatePolicy
       #   conversionStrategy: Default # optional, if not specified, the common from .spec field is used
       #   decodingStrategy:  None # optional, if not specified, the common from .spec field is used
       #   metadataPolicy:  None # optional, if not specified, the common from .spec field is used
@@ -93,10 +97,14 @@ externalSecret:
     
     secrets: {}
       # <secret-name>:
-      #   path: ""
-      #   targetName: "" # optional, overrides target.name (default: map key)
+      #   path: "" # required unless using generatorRef
+      #   targetName: "" # optional, overrides target Secret name (defaults to map key). Useful when merging into an existing operator-managed Secret with a different name.
       #   creationPolicy: Owner # optional, overrides spec-level creationPolicy
       #   deletionPolicy: Delete # optional, overrides spec-level deletionPolicy
+      #   generatorRef: # optional, if set uses dataFrom.sourceRef.generatorRef instead of data[].remoteRef
+      #     apiVersion: generators.external-secrets.io/v1alpha1
+      #     kind: Password
+      #     name: "generator-name"
       #   conversionStrategy: Default # optional, if not specified, the common from .spec field is used
       #   decodingStrategy:  None # optional, if not specified, the common from .spec field is used
       #   metadataPolicy:  None # optional, if not specified, the common from .spec field is used

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -6,6 +6,15 @@ externalSecret:
     kind: ClusterSecretStore
     name: "vault"
   
+  # -- Creates Password generator CRDs. Used with PushSecrets that have generatorRef selectors.
+  generators:
+    passwords: {}
+      # <name>:
+      #   spec:
+      #     length: 32
+      #     digits: 8
+      #     symbols: 0
+
   # -- Creates a PushSecret resource. It describes what data should be pushed to the SecretStore. This will be created also when pull is set to false.
   push:
     enabled: false
@@ -41,6 +50,11 @@ externalSecret:
     secrets: {}
       # <secret-name>:
       #   path: ""
+      #   sourceSecretName: "" # optional, overrides selector.secret.name (default: map key)
+      #   generatorRef: # optional, if set uses generatorRef selector instead of secret selector
+      #     apiVersion: generators.external-secrets.io/v1alpha1
+      #     kind: Password
+      #     name: "generator-name"
       #   conversionStrategy: Default # optional, if not specified, the common from .spec field is used
       #   decodingStrategy:  None # optional, if not specified, the common from .spec field is used
       #   metadataPolicy:  None # optional, if not specified, the common from .spec field is used
@@ -80,6 +94,9 @@ externalSecret:
     secrets: {}
       # <secret-name>:
       #   path: ""
+      #   targetName: "" # optional, overrides target.name (default: map key)
+      #   creationPolicy: Owner # optional, overrides spec-level creationPolicy
+      #   deletionPolicy: Delete # optional, overrides spec-level deletionPolicy
       #   conversionStrategy: Default # optional, if not specified, the common from .spec field is used
       #   decodingStrategy:  None # optional, if not specified, the common from .spec field is used
       #   metadataPolicy:  None # optional, if not specified, the common from .spec field is used


### PR DESCRIPTION
Done so we can use this with the elastic operator without nesting that logic in the eo chart. Tested on Playground as a local-chart. 