### PR TITLE
fix(kyverno): fix enforce-security-context mutation policy not applying to pods

### DIFF
--- a/charts/kyverno/templates/policies/enforce-security-context.yaml
+++ b/charts/kyverno/templates/policies/enforce-security-context.yaml
@@ -33,43 +33,41 @@ spec:
            {{- end }}
       {{- end }}
       mutate:
-        foreach:
-          - list: "request.object.spec.containers[]"
-            patchStrategicMerge:
-              metadata:
-                annotations:
-                  +(clusterpolicies.kyverno.io/add-pod-security-context): Added securityContext to pod, container and initContainer
-              spec:
-                securityContext:
-                  +(runAsNonRoot): true
-                  +(runAsUser): 1001
-                  +(runAsGroup): 1001
-                  seccompProfile:
-                    +(type): RuntimeDefault
-                containers:
-                  - (name): '*'
-                    securityContext:
-                      +(allowPrivilegeEscalation): false
-                      +(capabilities):
-                        drop:
-                          - ALL
-                      +(privileged): false
-                initContainers:
-                  - (name): '*'
-                    securityContext:
-                      +(allowPrivilegeEscalation): false
-                      +(capabilities):
-                        drop:
-                          - ALL
-                      +(privileged): false
-                ephemeralContainers:
-                  - (name): '*'
-                    securityContext:
-                      +(allowPrivilegeEscalation): false
-                      +(capabilities):
-                        drop:
-                          - ALL
-                      +(privileged): false
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              +(clusterpolicies.kyverno.io/add-pod-security-context): "Added securityContext to pod, container and initContainer"
+          spec:
+            securityContext:
+              +(runAsNonRoot): true
+              +(runAsUser): 1001
+              +(runAsGroup): 1001
+              seccompProfile:
+                +(type): RuntimeDefault
+            containers:
+            - (name): '*'
+              securityContext:
+                +(allowPrivilegeEscalation): false
+                +(capabilities):
+                  drop:
+                  - ALL
+                +(privileged): false
+            initContainers:
+            - (name): '*'
+              securityContext:
+                +(allowPrivilegeEscalation): false
+                +(capabilities):
+                  drop:
+                  - ALL
+                +(privileged): false
+            ephemeralContainers:
+            - (name): '*'
+              securityContext:
+                +(allowPrivilegeEscalation): false
+                +(capabilities):
+                  drop:
+                  - ALL
+                +(privileged): false
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The enforce-security-context ClusterPolicy was silently failing to mutate pods due to incorrect use of foreach with patchStrategicMerge.

This policy applied a whole-pod patch with wildcard name matching inside the foreach block. As a result, Kyverno skipped the mutation entirely, if pods already set a securityContext without reporting an error.
Fields like `seccompProfile` and `capabilities.drop: ALL` were never added, leaving pods non-compliant

**Fix**: Replace `foreach` + `patchStrategicMerge` with a plain `patchStrategicMerge` using wildcard `(name): '*'` matching, which correctly patches all containers, initContainers, and ephemeralContainers in a single pass.