### PR TITLE
Otc 406 fix prometheus stack alert rules

### DIFF
--- a/charts/prometheus-stack/CHANGELOG.md
+++ b/charts/prometheus-stack/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Chart Versions
 
+### 79.9.0
+
+- Make Prometheus pick also pick up `PrometheusRule` CRs outside of this deployment
+
 ### 79.8.2
 - Updates kube-prometheus-stack to 79.8.2
 - Updates blackbox exporter to 11.5.0

--- a/charts/prometheus-stack/CHANGELOG.md
+++ b/charts/prometheus-stack/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 79.9.0
 
 - Make Prometheus pick also pick up `PrometheusRule` CRs outside of this deployment
+- Increase version of `kube-prometheus-stack` to 79.9.0
 
 ### 79.8.2
 - Updates kube-prometheus-stack to 79.8.2

--- a/charts/prometheus-stack/Chart.lock
+++ b/charts/prometheus-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 79.8.2
+  version: 79.9.0
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 11.5.0
-digest: sha256:196af1adba4ea7ccdb7dc1bca0e036cadd3183001f8eecb7e696a7f2ee882227
-generated: "2025-11-27T10:49:23.644126+01:00"
+digest: sha256:6167994448e1b434cc04c4199805819482b0b828c8e3232bc435e9e1a9bf3a0c
+generated: "2026-04-24T15:13:02.258845281+02:00"

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -3,7 +3,7 @@ dependencies:
   - alias: prometheusStack
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 79.8.2
+    version: 79.9.0
   - alias: blackboxExporter
     condition: blackboxExporter.enabled
     name: prometheus-blackbox-exporter
@@ -36,5 +36,5 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 79.8.2
+version: 79.9.0
 appVersion: 3.7.3

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,6 +1,6 @@
 # prometheus-stack
 
-![Version: 79.8.2](https://img.shields.io/badge/Version-79.8.2-informational?style=flat-square) ![AppVersion: 3.7.3](https://img.shields.io/badge/AppVersion-3.7.3-informational?style=flat-square)
+![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.7.3](https://img.shields.io/badge/AppVersion-3.7.3-informational?style=flat-square)
 
 A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
 
@@ -32,7 +32,7 @@ prometheus-stack:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.8.2 |
+| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.9.0 |
 | https://prometheus-community.github.io/helm-charts | blackboxExporter(prometheus-blackbox-exporter) | 11.5.0 |
 
 ## Values
@@ -157,6 +157,7 @@ prometheus-stack:
 | prometheusStack.prometheus.prometheusSpec.resources.requests.memory | string | `"2255Mi"` |  |
 | prometheusStack.prometheus.prometheusSpec.retention | string | `"1y"` |  |
 | prometheusStack.prometheus.prometheusSpec.routePrefix | string | `"/prometheus"` |  |
+| prometheusStack.prometheus.prometheusSpec.ruleSelectorNilUsesHelmValues | bool | `false` |  |
 | prometheusStack.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues | bool | `false` |  |
 | prometheusStack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | prometheusStack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage | string | `"250G"` |  |

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -58,6 +58,7 @@ prometheusStack:
     prometheusSpec:
       externalUrl: https://{{$.Values.global.ingress.host}}{{$.Values.global.ingress.paths.prometheus}}
       routePrefix: "/prometheus"
+      ruleSelectorNilUsesHelmValues: false
       serviceMonitorSelectorNilUsesHelmValues: false
       podMonitorSelectorNilUsesHelmValues: false
       probeSelectorNilUsesHelmValues: false


### PR DESCRIPTION
See comments on OTC-406 or OTC-410 _(link intentionally not posted)_
Prometheus is not picking up `PrometheusRule` resources deployed outside of the `prometheus-stack` helm chart. PR should change this by setting the values accordingly.
Version increase on the `kube-prometheus-stack` chart in `dependencies` is just to keep it in sync with `version` on this chart.