### PR TITLE
OTC-234: Prometheus-stack ESO integration

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
 

--- a/charts/prometheus-stack/CHANGELOG.md
+++ b/charts/prometheus-stack/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Make Prometheus pick also pick up `PrometheusRule` CRs outside of this deployment
 - Increase version of `kube-prometheus-stack` to 79.9.0
+- Added common chart lib as dependency chart
+- Adds custom configMap template for Blackbox Exporter config via External Secrets, when enabled
 
 ### 79.8.2
 - Updates kube-prometheus-stack to 79.8.2

--- a/charts/prometheus-stack/Chart.lock
+++ b/charts/prometheus-stack/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 11.5.0
-digest: sha256:6167994448e1b434cc04c4199805819482b0b828c8e3232bc435e9e1a9bf3a0c
-generated: "2026-04-24T15:13:02.258845281+02:00"
+- name: common
+  repository: https://charts.iits.tech
+  version: 0.3.1
+digest: sha256:0a857f3973f7dabb95e1f24a8e81d30bd4f462a5eceb37f8b3acec83eb8079a0
+generated: "2026-05-05T14:52:28.556935+02:00"

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -9,6 +9,9 @@ dependencies:
     name: prometheus-blackbox-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 11.5.0
+  - name: common
+    repository: https://charts.iits.tech
+    version: 0.2.0
 description: |
   A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
   
@@ -37,4 +40,4 @@ description: |
   ```
 name: prometheus-stack
 version: 79.9.0
-appVersion: 3.7.3
+appVersion: 3.9.0

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 11.5.0
   - name: common
     repository: https://charts.iits.tech
-    version: 0.2.0
+    version: 0.3.1
 description: |
   A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
   

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -39,5 +39,5 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 79.9.0
+version: 79.10.0
 appVersion: 3.9.0

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,6 +1,10 @@
 # prometheus-stack
 
+<<<<<<< HEAD
 ![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.7.3](https://img.shields.io/badge/AppVersion-3.7.3-informational?style=flat-square)
+=======
+![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+>>>>>>> 3bd67be (Auto update of README.md files)
 
 A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
 
@@ -33,6 +37,7 @@ prometheus-stack:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.9.0 |
+| https://charts.iits.tech | common | 0.2.0 |
 | https://prometheus-community.github.io/helm-charts | blackboxExporter(prometheus-blackbox-exporter) | 11.5.0 |
 
 ## Values
@@ -65,6 +70,7 @@ prometheus-stack:
 | blackboxExporter.serviceMonitor.targets | string | `nil` |  |
 | blackboxExporter.strategy.rollingUpdate | string | `nil` |  |
 | blackboxExporter.strategy.type | string | `"Recreate"` |  |
+| common.externalSecret.enabled | bool | `false` |  |
 | dashboards.enabled | bool | `true` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.entrypoints" | string | `"websecure"` |  |
 | global.ingress.annotations."traefik.ingress.kubernetes.io/router.middlewares" | string | `"routing-oidc-forward-auth@kubernetescrd"` |  |

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,10 +1,6 @@
 # prometheus-stack
 
-<<<<<<< HEAD
-![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.7.3](https://img.shields.io/badge/AppVersion-3.7.3-informational?style=flat-square)
-=======
 ![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
->>>>>>> 3bd67be (Auto update of README.md files)
 
 A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
 
@@ -36,8 +32,8 @@ prometheus-stack:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.9.0 |
 | https://charts.iits.tech | common | 0.2.0 |
+| https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.9.0 |
 | https://prometheus-community.github.io/helm-charts | blackboxExporter(prometheus-blackbox-exporter) | 11.5.0 |
 
 ## Values

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -32,7 +32,7 @@ prometheus-stack:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.iits.tech | common | 0.2.0 |
+| https://charts.iits.tech | common | 0.3.1 |
 | https://prometheus-community.github.io/helm-charts | prometheusStack(kube-prometheus-stack) | 79.9.0 |
 | https://prometheus-community.github.io/helm-charts | blackboxExporter(prometheus-blackbox-exporter) | 11.5.0 |
 

--- a/charts/prometheus-stack/README.md
+++ b/charts/prometheus-stack/README.md
@@ -1,6 +1,6 @@
 # prometheus-stack
 
-![Version: 79.9.0](https://img.shields.io/badge/Version-79.9.0-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+![Version: 79.10.0](https://img.shields.io/badge/Version-79.10.0-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
 
 A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
 

--- a/charts/prometheus-stack/templates/configMap.yaml
+++ b/charts/prometheus-stack/templates/configMap.yaml
@@ -1,0 +1,17 @@
+{{/*
+The ConfigMap below is not mounted into BlackBox Exporter directly — it's only used by External Secrets Operator as a rendering template. 
+BlackBox Exporter only ever sees the final rendered Secret. The ConfigMap does not contain any sensitive values that might exist 
+on the config itself (ie. basic_auth, oauth2 etc.), but only placeholders where ESO is using to inject the real values dynamically
+*/}}
+{{- with .Values.common.externalSecret }}
+{{- if and .enabled $.Values.blackboxExporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Values.blackboxExporter.configFromTemplate.name }}
+data:
+  blackbox.yaml: |
+{{- toYaml $.Values.blackboxExporter.configFromTemplate.config | nindent 4 }}
+{{- end }}
+{{- end }}
+        

--- a/charts/prometheus-stack/templates/configMap.yaml
+++ b/charts/prometheus-stack/templates/configMap.yaml
@@ -1,10 +1,10 @@
 {{/*
-The ConfigMap below is not mounted into BlackBox Exporter directly — it's only used by External Secrets Operator as a rendering template. 
-BlackBox Exporter only ever sees the final rendered Secret. The ConfigMap does not contain any sensitive values that might exist 
+The ConfigMap below is not mounted into BlackBox Exporter directly — it's only used by External Secrets Operator as a rendering template.
+BlackBox Exporter only ever sees the final rendered Secret. The ConfigMap does not contain any sensitive values that might exist
 on the config itself (ie. basic_auth, oauth2 etc.), but only placeholders where ESO is using to inject the real values dynamically
 */}}
 {{- with .Values.common.externalSecret }}
-{{- if and .enabled $.Values.blackboxExporter.enabled }}
+{{- if and .enabled $.Values.blackboxExporter.enabled $.Values.blackboxExporter.configFromTemplate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,4 +14,3 @@ data:
 {{- toYaml $.Values.blackboxExporter.configFromTemplate.config | nindent 4 }}
 {{- end }}
 {{- end }}
-        

--- a/charts/prometheus-stack/values.yaml
+++ b/charts/prometheus-stack/values.yaml
@@ -99,6 +99,17 @@ prometheusStack:
       patch:
         enabled: false
   grafana:
+    # Example below client_id and client_secret via envFromSecret in case External Secrets is used. 
+    # In this case secretKeyRef.name has to match with ESO's secret-name key under common.externalSecret.pull config
+    # envValueFrom:
+    #   GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+    #     secretKeyRef:
+    #       name: <grafana-secret-name>
+    #       key: clientsecret
+    #   GF_AUTH_GENERIC_OAUTH_CLIENT_ID:
+    #     secretKeyRef:
+    #       name: <grafana-secret-name>
+    #       key: clientid
     sidecar:
       dashboards:
         enabled: true
@@ -124,6 +135,10 @@ prometheusStack:
     config:
       global:
         resolve_timeout: 5m
+        # Remove `slack_api_url` in case External Secrets is used. 
+        # Instead, make use of _file directive to mount ESO's the releavant secret as volume mount, like below. 
+        # Secret mounts can be defined under `alertmanagerSpec.secrets`
+        # slack_api_url_file: /etc/alertmanager/secrets/<alertmanager-secret-name>/slack_api_url
         slack_api_url: "http://myhost.local"
       route:
         group_by: [ 'job' ]
@@ -161,6 +176,10 @@ prometheusStack:
       templates:
         - /etc/alertmanager/config/*.tmpl
     alertmanagerSpec:
+      # Mount the ESO-managed secret into the Alertmanager pod. 
+      # In this case <alertmanager-secret-name> has to match with ESO's <alertmanager-secret-name> key under common.externalSecret.pull config
+      # secrets:
+      #   - <alertmanager-secret-name>
       externalUrl: https://{{$.Values.global.ingress.host}}{{$.Values.global.ingress.paths.alertmanager}}
       routePrefix: "/alertmanager"
       resources:
@@ -189,6 +208,20 @@ blackboxExporter:
       memory: 100Mi
     limits:
       memory: 100Mi
+  
+  # To make use of ESO generated config, disable the built-in Helm-managed config and move everything under `configFromTemplate.config`. 
+  # This will generate a configMap resource as template, for ESO to consume. Example below as reference:
+  # config: {}
+  # configFromTemplate:
+  #   name: <blackbox-exporter-config-template> # has to match ESO's template.templateFrom[].configMap.name:
+  #   config: 
+  #     ...
+  #           oauth2:
+  #             client_id: "{{ `{{ .client_id }}` }}" # for Helm/ESO secret injection
+  #             client_secret: "{{ `{{ .client_secret }}` }}" # for Helm/ESO secret injection
+  #     ...
+  # configExistingSecretName: <blackbox-exporter-secret-name>: # has to match the name of the generated ESO secret under common.externalSecret.pull config
+  
   config:
     modules:
       http_2xx:
@@ -269,3 +302,37 @@ uptimeMonitors:
   targets: []
     # - name: my-target
     #   url: https://app.example.com/
+
+# https://github.com/iits-consulting/charts/tree/main/charts/common
+# Global functionality can be used from the common library chart, e.g. creating External Secrets. 
+# Below example to use as template for this stack.
+common:
+  externalSecret:
+    enabled: false
+#     pull:
+#       enabled: true
+#       secrets:
+#         <alertmanager-secret-name>: # has to be present in `alertmanagerSpec.secrets` to be mounted as volume
+#           path: ""
+#           keys:
+#             - name: "slack_api_url"
+#         <grafana-secret-name>: # has to match envFrom.<ENV>.secretKeyRef.name
+#           path: ""
+#           keys:
+#             - name: "clientid"
+#               remoteKey: "client_id"  
+#             - name: "clientsecret"
+#               remoteKey: "client_secret"
+#         <blackbox-exporter-secret-name>:
+#           path: ""
+#           keys:
+#             - name: client_id
+#             - name: client_secret
+#           template:
+#             templateFrom:
+#               - target: Data
+#                 configMap:
+#                   name: <blackbox-exporter-config-template> # has to match `configFromTemplate.name`
+#                   items:
+#                     - key: blackbox.yaml # matches the `blackbox.yaml` key in relevant configMap in templates
+#                       templateAs: Values


### PR DESCRIPTION

- adds support in prometheusStack for secrets in BBE (Blackbox Exporter) config, Grafana and AlertManager
- ExternalSecrets as feature is disabled by default (for backwards compatibility)

Tested on playground-dev environment via infrastructure charts

ESO details in particular for each component:

- envFrom.secretkeyRef works natively in secrets for Grafana config (via the `GF_<env>` directive)
- Alertmanager uses mounted secret via ESO generated secret (using the `_file` directive for the webhook url for slack)
- BBE required more elaborate approach, since env expansion in its config is not supported. `templateFrom` for custom configMap with placeholders was used to be able for ESO to create a generated config as secret (as before) for BBE to pick up (oauth2 secrets). built-in config can not used in BBE in this case and has to be set to `{}`

**Notes:**
- Bumped both Chart version and appVersion, to next minor. up for discussion since there is not really a clear agreement on how to treat those, at least for cases like this multi-chart.
- Possible improvements would be to use templating in values.yaml for the references of resources (secrets), but in some cases (like BBE) is anyway part of the pre-exising 'nuissance' which is inherited from Upstream, and can't be changed that much.
