### PR TITLE
feat(elastalert): integrate ESO for Slack webhook URL via common sub-chart

### DIFF
--- a/charts/elastalert/Chart.lock
+++ b/charts/elastalert/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: elastalert2
   repository: https://jertel.github.io/elastalert2/
   version: 2.24.0
-digest: sha256:555b347fa73d43d163f31b09b71f2e3d04ec916c948811d07766746c5b4750c0
-generated: "2025-04-29T10:11:28.496359+02:00"
+- name: common
+  repository: https://charts.iits.tech
+  version: 0.1.0
+digest: sha256:7e3de928b94d3f1484e9059a34d4b343d8d53b893487c7284c1cfdeb3cfc0157
+generated: "2026-04-27T18:38:05.045826+02:00"

--- a/charts/elastalert/Chart.lock
+++ b/charts/elastalert/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.24.0
 - name: common
   repository: https://charts.iits.tech
-  version: 0.1.0
-digest: sha256:7e3de928b94d3f1484e9059a34d4b343d8d53b893487c7284c1cfdeb3cfc0157
-generated: "2026-04-27T18:38:05.045826+02:00"
+  version: 0.3.1
+digest: sha256:016107250906721e8c5b688601658f55881e3282466d830432ee87e1d26dfd33
+generated: "2026-05-12T11:43:18.259487+02:00"

--- a/charts/elastalert/Chart.yaml
+++ b/charts/elastalert/Chart.yaml
@@ -1,24 +1,57 @@
 apiVersion: v2
 description: |
   Wrapper chart for elastalert2 with custom rules to kickstart IITS projects
-  
+
   ## Installing the Chart with iits ArgoCD
-  
+
+  There are two ways to provide the Slack webhook URL.
+
+  ### Option 1: ExternalSecretsOperator
+
+  Use the built-in ESO integration to pull the webhook URL from Vault into a Kubernetes Secret.
+  The pod reads it as `SLACK_WEBHOOK_URL` via an environment variable.
+
   ```yaml
   elastalert:
     namespace: monitoring
     repoURL: "https://charts.iits.tech"
-    targetRevision: "0.3.0"
-    # If you need custom rules
+    targetRevision: "0.5.0"
+    valueFile: "value-files/elastalert/values.yaml"
+  ```
+
+  `value-files/elastalert/values.yaml`:
+  ```yaml
+  common:
+    externalSecret:
+      enabled: true
+      pull:
+        enabled: true
+        secrets:
+          elastalert-slack-webhook:
+            path: "myProject/data/common/slack"
+            keys:
+              - name: slack_webhook_url
+  ```
+
+  ### Option 2: ArgoCD vault plugin (direct parameter)
+
+  ```yaml
+  elastalert:
+    namespace: monitoring
+    repoURL: "https://charts.iits.tech"
+    targetRevision: "0.5.0"
     valueFile: "value-files/elastalert/values.yaml"
     parameters:
       customRules.slack.webhookUrl: "${vault:mySecretPath/data/common/slack#webhookUrl}"
   ```
 
 name: elastalert
-version: 0.4.0
+version: 0.5.0
 dependencies:
   - name: elastalert2
     repository: https://jertel.github.io/elastalert2/
     version: 2.24.0
+  - name: common
+    repository: https://charts.iits.tech
+    version: 0.1.0
 type: application

--- a/charts/elastalert/Chart.yaml
+++ b/charts/elastalert/Chart.yaml
@@ -53,5 +53,5 @@ dependencies:
     version: 2.24.0
   - name: common
     repository: https://charts.iits.tech
-    version: 0.1.0
+    version: 0.3.1
 type: application

--- a/charts/elastalert/README.md
+++ b/charts/elastalert/README.md
@@ -1,17 +1,47 @@
 # elastalert
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for elastalert2 with custom rules to kickstart IITS projects
 
 ## Installing the Chart with iits ArgoCD
 
+There are two ways to provide the Slack webhook URL.
+
+### Option 1: ExternalSecretsOperator
+
+Use the built-in ESO integration to pull the webhook URL from Vault into a Kubernetes Secret.
+The pod reads it as `SLACK_WEBHOOK_URL` via an environment variable.
+
 ```yaml
 elastalert:
   namespace: monitoring
   repoURL: "https://charts.iits.tech"
-  targetRevision: "0.3.0"
-  # If you need custom rules
+  targetRevision: "0.5.0"
+  valueFile: "value-files/elastalert/values.yaml"
+```
+
+`value-files/elastalert/values.yaml`:
+```yaml
+common:
+  externalSecret:
+    enabled: true
+    pull:
+      enabled: true
+      secrets:
+        elastalert-slack-webhook:
+          path: "myProject/data/common/slack"
+          keys:
+            - name: slack_webhook_url
+```
+
+### Option 2: ArgoCD vault plugin (direct parameter)
+
+```yaml
+elastalert:
+  namespace: monitoring
+  repoURL: "https://charts.iits.tech"
+  targetRevision: "0.5.0"
   valueFile: "value-files/elastalert/values.yaml"
   parameters:
     customRules.slack.webhookUrl: "${vault:mySecretPath/data/common/slack#webhookUrl}"
@@ -21,12 +51,19 @@ elastalert:
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.iits.tech | common | 0.1.0 |
 | https://jertel.github.io/elastalert2/ | elastalert2 | 2.24.0 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| common.externalSecret.enabled | bool | `false` |  |
+| common.externalSecret.pull.enabled | bool | `false` |  |
+| common.externalSecret.pull.secrets.elastalert-slack-webhook.keys[0].name | string | `"slack_webhook_url"` |  |
+| common.externalSecret.pull.secrets.elastalert-slack-webhook.path | string | `""` |  |
+| common.externalSecret.secretStore.kind | string | `"ClusterSecretStore"` |  |
+| common.externalSecret.secretStore.name | string | `"vault"` |  |
 | customRules.alerting.argoCD.alert[0] | string | `"slack"` |  |
 | customRules.alerting.argoCD.alert_text_args[0] | string | `"@timestamp"` |  |
 | customRules.alerting.argoCD.alert_text_type | string | `"aggregation_summary_only"` |  |
@@ -46,7 +83,6 @@ elastalert:
 | customRules.alerting.argoCD.slack_alert_fields[3].title | string | `"Message"` |  |
 | customRules.alerting.argoCD.slack_alert_fields[3].value | string | `"message"` |  |
 | customRules.alerting.argoCD.slack_title | string | `"ArgoCD Error"` |  |
-| customRules.alerting.argoCD.slack_webhook_url | string | `"{{ $.Values.customRules.slack.webhookUrl }}"` |  |
 | customRules.alerting.argoCD.type | string | `"any"` |  |
 | customRules.alerting.botKube.alert[0] | string | `"slack"` |  |
 | customRules.alerting.botKube.alert_text_type | string | `"aggregation_summary_only"` |  |
@@ -72,7 +108,6 @@ elastalert:
 | customRules.alerting.botKube.slack_alert_fields[6].title | string | `"Reason"` |  |
 | customRules.alerting.botKube.slack_alert_fields[6].value | string | `"Reason"` |  |
 | customRules.alerting.botKube.slack_title | string | `"Botkube Error"` |  |
-| customRules.alerting.botKube.slack_webhook_url | string | `"{{ $.Values.customRules.slack.webhookUrl }}"` |  |
 | customRules.alerting.botKube.timestamp_field | string | `"TimeStamp"` |  |
 | customRules.alerting.botKube.type | string | `"any"` |  |
 | customRules.alerting.kafkaTopicCreatedNotification.alert[0] | string | `"slack"` |  |
@@ -104,7 +139,6 @@ elastalert:
 | customRules.alerting.kafkaTopicCreatedNotification.slack_alert_fields[7].title | string | `"User"` |  |
 | customRules.alerting.kafkaTopicCreatedNotification.slack_alert_fields[7].value | string | `"user"` |  |
 | customRules.alerting.kafkaTopicCreatedNotification.slack_title | string | `"Kafka Topic Notification"` |  |
-| customRules.alerting.kafkaTopicCreatedNotification.slack_webhook_url | string | `"{{ $.Values.customRules.slack.webhookUrl }}"` |  |
 | customRules.alerting.kafkaTopicCreatedNotification.type | string | `"any"` |  |
 | customRules.alerting.kyverno.alert[0] | string | `"slack"` |  |
 | customRules.alerting.kyverno.alert_text_args[0] | string | `"@timestamp"` |  |
@@ -125,7 +159,6 @@ elastalert:
 | customRules.alerting.kyverno.slack_alert_fields[3].title | string | `"Message"` |  |
 | customRules.alerting.kyverno.slack_alert_fields[3].value | string | `"message"` |  |
 | customRules.alerting.kyverno.slack_title | string | `"Kyverno Error"` |  |
-| customRules.alerting.kyverno.slack_webhook_url | string | `"{{ $.Values.customRules.slack.webhookUrl }}"` |  |
 | customRules.alerting.kyverno.type | string | `"any"` |  |
 | customRules.alerting.vaultInjection.alert[0] | string | `"slack"` |  |
 | customRules.alerting.vaultInjection.alert_text_args[0] | string | `"@time"` |  |
@@ -146,10 +179,13 @@ elastalert:
 | customRules.alerting.vaultInjection.slack_alert_fields[3].title | string | `"Error"` |  |
 | customRules.alerting.vaultInjection.slack_alert_fields[3].value | string | `"error"` |  |
 | customRules.alerting.vaultInjection.slack_title | string | `"Vault Injection Error"` |  |
-| customRules.alerting.vaultInjection.slack_webhook_url | string | `"{{ $.Values.customRules.slack.webhookUrl }}"` |  |
 | customRules.alerting.vaultInjection.type | string | `"any"` |  |
-| customRules.slack.webhookUrl | string | `nil` | Required |
+| customRules.slack.webhookUrl | string | `nil` | Slack webhook URL injected directly. Used when common.externalSecret.enabled=false. For ArgoCD vault plugin: parameters: customRules.slack.webhookUrl: "${vault:...}" |
 | elastalert2.elasticsearch.host | string | `"elasticsearch-master"` | needs to be in the same namespaces as elastic stack if used like this |
+| elastalert2.optEnv[0].name | string | `"SLACK_WEBHOOK_URL"` |  |
+| elastalert2.optEnv[0].valueFrom.secretKeyRef.key | string | `"slack_webhook_url"` |  |
+| elastalert2.optEnv[0].valueFrom.secretKeyRef.name | string | `"elastalert-slack-webhook"` |  |
+| elastalert2.optEnv[0].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | elastalert2.secretRulesList[0] | string | `"argoCD"` |  |
 | elastalert2.secretRulesList[1] | string | `"botKube"` |  |
 | elastalert2.secretRulesList[2] | string | `"vaultInjection"` |  |

--- a/charts/elastalert/README.md
+++ b/charts/elastalert/README.md
@@ -51,7 +51,7 @@ elastalert:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.iits.tech | common | 0.1.0 |
+| https://charts.iits.tech | common | 0.3.1 |
 | https://jertel.github.io/elastalert2/ | elastalert2 | 2.24.0 |
 
 ## Values
@@ -182,10 +182,6 @@ elastalert:
 | customRules.alerting.vaultInjection.type | string | `"any"` |  |
 | customRules.slack.webhookUrl | string | `nil` | Slack webhook URL injected directly. Used when common.externalSecret.enabled=false. For ArgoCD vault plugin: parameters: customRules.slack.webhookUrl: "${vault:...}" |
 | elastalert2.elasticsearch.host | string | `"elasticsearch-master"` | needs to be in the same namespaces as elastic stack if used like this |
-| elastalert2.optEnv[0].name | string | `"SLACK_WEBHOOK_URL"` |  |
-| elastalert2.optEnv[0].valueFrom.secretKeyRef.key | string | `"slack_webhook_url"` |  |
-| elastalert2.optEnv[0].valueFrom.secretKeyRef.name | string | `"elastalert-slack-webhook"` |  |
-| elastalert2.optEnv[0].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | elastalert2.secretRulesList[0] | string | `"argoCD"` |  |
 | elastalert2.secretRulesList[1] | string | `"botKube"` |  |
 | elastalert2.secretRulesList[2] | string | `"vaultInjection"` |  |

--- a/charts/elastalert/templates/custom_rules.yaml
+++ b/charts/elastalert/templates/custom_rules.yaml
@@ -1,9 +1,19 @@
+{{- $esoSecrets := (((.Values.common).externalSecret).pull).secrets | default dict }}
+{{- $esoActive := and (((.Values.common).externalSecret).enabled) ((((.Values.common).externalSecret).pull).enabled) (index $esoSecrets "elastalert-slack-webhook") }}
+{{- if and $esoActive .Values.customRules.slack.webhookUrl }}
+{{- fail "Cannot set both ESO mode (common.externalSecret.enabled + pull.enabled + elastalert-slack-webhook) and customRules.slack.webhookUrl — use one webhook injection method." }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
   name: {{ .Release.Name }}-custom-rules
 stringData:
-  {{- range $key,$rule := .Values.customRules.alerting }}
-  {{ $key | indent 4 }}: |- {{ tpl (toYaml $rule) $ | toString | nindent 10}}
+  {{- $slackWebhookUrl := .Values.customRules.slack.webhookUrl | default "" }}
+  {{- if ((.Values.common).externalSecret).enabled }}
+  {{- $slackWebhookUrl = "${SLACK_WEBHOOK_URL}" }}
+  {{- end }}
+  {{- range $key, $rule := .Values.customRules.alerting }}
+  {{- $ruleWithWebhook := merge (deepCopy $rule) (dict "slack_webhook_url" $slackWebhookUrl) }}
+  {{ $key | indent 4 }}: |- {{ tpl (toYaml $ruleWithWebhook) $ | toString | nindent 10}}
   {{- end }}

--- a/charts/elastalert/tests/custom_rules_test.yaml
+++ b/charts/elastalert/tests/custom_rules_test.yaml
@@ -1,0 +1,86 @@
+suite: custom_rules Secret
+templates:
+  - custom_rules.yaml
+
+release:
+  name: elastalert
+
+tests:
+  - it: should embed webhook URL directly when ESO is disabled
+    set:
+      customRules.slack.webhookUrl: "https://hooks.slack.com/services/TEST"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: elastalert-custom-rules
+      - matchRegex:
+          path: stringData.argoCD
+          pattern: "slack_webhook_url: https://hooks.slack.com/services/TEST"
+      - matchRegex:
+          path: stringData.botKube
+          pattern: "slack_webhook_url: https://hooks.slack.com/services/TEST"
+
+  - it: should use env var reference for all rules when ESO is enabled
+    set:
+      common.externalSecret.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData.argoCD
+          pattern: "slack_webhook_url: \\$\\{SLACK_WEBHOOK_URL\\}"
+      - matchRegex:
+          path: stringData.botKube
+          pattern: "slack_webhook_url: \\$\\{SLACK_WEBHOOK_URL\\}"
+      - matchRegex:
+          path: stringData.vaultInjection
+          pattern: "slack_webhook_url: \\$\\{SLACK_WEBHOOK_URL\\}"
+      - matchRegex:
+          path: stringData.kyverno
+          pattern: "slack_webhook_url: \\$\\{SLACK_WEBHOOK_URL\\}"
+      - matchRegex:
+          path: stringData.kafkaTopicCreatedNotification
+          pattern: "slack_webhook_url: \\$\\{SLACK_WEBHOOK_URL\\}"
+
+  - it: should use empty webhook URL when ESO is disabled and no URL provided
+    asserts:
+      - matchRegex:
+          path: stringData.argoCD
+          pattern: "slack_webhook_url: \"\""
+
+  - it: should fail when ESO mode and webhookUrl are both set
+    values:
+      - eso_values.yaml
+    set:
+      customRules.slack.webhookUrl: "https://hooks.slack.com/services/TEST"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot set both ESO mode (common.externalSecret.enabled + pull.enabled + elastalert-slack-webhook) and customRules.slack.webhookUrl — use one webhook injection method."
+
+  - it: should not fail when ESO is enabled but pull is disabled and webhookUrl is set
+    set:
+      common.externalSecret.enabled: true
+      common.externalSecret.pull.enabled: false
+      customRules.slack.webhookUrl: "https://hooks.slack.com/services/TEST"
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: should not fail when ESO is fully enabled but webhookUrl is not set
+    values:
+      - eso_values.yaml
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: should keep per-rule slack_webhook_url when rule defines its own
+    set:
+      customRules.slack.webhookUrl: "https://hooks.slack.com/services/GLOBAL"
+      customRules.alerting.argoCD.slack_webhook_url: "https://hooks.slack.com/services/OVERRIDE"
+    asserts:
+      - matchRegex:
+          path: stringData.argoCD
+          pattern: "slack_webhook_url: https://hooks.slack.com/services/OVERRIDE"
+      - matchRegex:
+          path: stringData.botKube
+          pattern: "slack_webhook_url: https://hooks.slack.com/services/GLOBAL"

--- a/charts/elastalert/tests/eso_custom_remotekey_values.yaml
+++ b/charts/elastalert/tests/eso_custom_remotekey_values.yaml
@@ -1,0 +1,11 @@
+common:
+  externalSecret:
+    enabled: true
+    pull:
+      enabled: true
+      secrets:
+        elastalert-slack-webhook:
+          path: "myProject/data/stage/alerting"
+          keys:
+            - name: slack_webhook_url
+              remoteKey: different_key_in_vault

--- a/charts/elastalert/tests/eso_test.yaml
+++ b/charts/elastalert/tests/eso_test.yaml
@@ -1,0 +1,53 @@
+suite: ESO ExternalSecret via common sub-chart
+templates:
+  - charts/common/templates/external-secret.yaml
+
+release:
+  name: elastalert
+
+tests:
+  - it: should not create ExternalSecret when ESO is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create ExternalSecret for slack webhook when ESO is enabled
+    values:
+      - eso_values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: elastalert-slack-webhook
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault
+      - equal:
+          path: spec.target.name
+          value: elastalert-slack-webhook
+      - equal:
+          path: spec.data[0].secretKey
+          value: slack_webhook_url
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: "myProject/data/common/slack"
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: slack_webhook_url  # defaults to key name when remoteKey is not set
+
+  - it: should use custom remoteKey when vault key name differs from the K8s secret key
+    values:
+      - eso_custom_remotekey_values.yaml
+    asserts:
+      - equal:
+          path: spec.data[0].secretKey
+          value: slack_webhook_url
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: different_key_in_vault

--- a/charts/elastalert/tests/eso_values.yaml
+++ b/charts/elastalert/tests/eso_values.yaml
@@ -1,0 +1,10 @@
+common:
+  externalSecret:
+    enabled: true
+    pull:
+      enabled: true
+      secrets:
+        elastalert-slack-webhook:
+          path: "myProject/data/common/slack"
+          keys:
+            - name: slack_webhook_url

--- a/charts/elastalert/values.yaml
+++ b/charts/elastalert/values.yaml
@@ -2,6 +2,16 @@ elastalert2:
   elasticsearch:
     # -- needs to be in the same namespaces as elastic stack if used like this
     host: elasticsearch-master
+  # Mounts SLACK_WEBHOOK_URL from the ESO-created secret. optional=true keeps the pod
+  # running when ESO is disabled and the secret does not exist.
+  # Override secretKeyRef.name to match common.externalSecret.pull.secrets key if changed.
+  optEnv:
+    - name: SLACK_WEBHOOK_URL
+      valueFrom:
+        secretKeyRef:
+          name: elastalert-slack-webhook
+          key: slack_webhook_url
+          optional: true
   secretRulesName: elastalert-custom-rules
   secretRulesList:
     - argoCD
@@ -29,8 +39,17 @@ elastalert2:
   #   credentialsSecretPasswordKey: password
 customRules:
   slack:
-    # -- Required
+    # -- Slack webhook URL injected directly. Used when common.externalSecret.enabled=false.
+    # For ArgoCD vault plugin: parameters: customRules.slack.webhookUrl: "${vault:...}"
     webhookUrl:
+  # Alert rules. Each entry is rendered as a separate elastalert2 rule file.
+  # The global slack.webhookUrl (or ${SLACK_WEBHOOK_URL} in ESO mode) is injected into
+  # every rule automatically. Individual rules can override this by setting their own
+  # slack_webhook_url, which takes precedence over the global value:
+  #   alerting:
+  #     myRule:
+  #       slack_webhook_url: "https://hooks.slack.com/services/other-channel"
+  #       ...
   alerting:
     argoCD:
       name: ArgoCD Error
@@ -51,7 +70,6 @@ customRules:
         - query_string:
             query: "level: \"*error*\" OR message: \"*level=error*\""
       slack_title: ArgoCD Error
-      slack_webhook_url: "{{ $.Values.customRules.slack.webhookUrl }}"
       slack_alert_fields:
         - title: Stage
           value: labels.stage
@@ -80,7 +98,6 @@ customRules:
         - query_string:
             query: "Type:\"error\""
       slack_title: Botkube Error
-      slack_webhook_url: "{{ $.Values.customRules.slack.webhookUrl }}"
       slack_alert_fields:
         - title: Cluster
           value: Cluster
@@ -114,7 +131,6 @@ customRules:
       filter:
         - eql: any where message like~ "\\[ERROR\\]"
       slack_title: Vault Injection Error
-      slack_webhook_url: "{{ $.Values.customRules.slack.webhookUrl }}"
       slack_alert_fields:
         - title: Stage
           value: labels.stage
@@ -143,7 +159,6 @@ customRules:
         - query_string:
             query: "message: \"validation failed\" OR message: \"policy validation errors\""
       slack_title: Kyverno Error
-      slack_webhook_url: "{{ $.Values.customRules.slack.webhookUrl }}"
       slack_alert_fields:
         - title: Stage
           value: labels.stage
@@ -173,7 +188,6 @@ customRules:
               query: "message: \"Creating topic\" AND \"with configuration\" AND \"and initial partition assignment\""
         slack:
         slack_title: Kafka Topic Notification
-        slack_webhook_url: "{{ $.Values.customRules.slack.webhookUrl }}"
         slack_alert_fields:
         - title: Stage
           value: labels.stage
@@ -192,3 +206,28 @@ customRules:
           value: stacktrace
         - title: User
           value: user
+
+# Opt-in ESO integration via the common sub-chart.
+# When enabled, an ExternalSecret pulls the Slack webhook URL from the secret store
+# and writes it into the elastalert-slack-webhook K8s Secret as key "slack_webhook_url".
+# The pod then reads it as SLACK_WEBHOOK_URL via elastalert2.optEnv above.
+# Must also set common.externalSecret.pull.enabled=true and configure the secrets path.
+#
+# remoteKey is optional: if omitted it defaults to the key name ("slack_webhook_url").
+# Set it explicitly when the key in your secret store has a different name, e.g.:
+#   keys:
+#     - name: slack_webhook_url
+#       remoteKey: different_key_in_vault
+common:
+  externalSecret:
+    enabled: false
+    secretStore:
+      kind: ClusterSecretStore
+      name: vault
+    pull:
+      enabled: false
+      secrets:
+        elastalert-slack-webhook:
+          path: ""  # -- Required: path to the secret in your store, e.g. "context/data/stage/alerting"
+          keys:
+            - name: slack_webhook_url

--- a/charts/elastalert/values.yaml
+++ b/charts/elastalert/values.yaml
@@ -2,16 +2,15 @@ elastalert2:
   elasticsearch:
     # -- needs to be in the same namespaces as elastic stack if used like this
     host: elasticsearch-master
-  # Mounts SLACK_WEBHOOK_URL from the ESO-created secret. optional=true keeps the pod
-  # running when ESO is disabled and the secret does not exist.
+  # Mounts SLACK_WEBHOOK_URL from the ESO-created secret.
   # Override secretKeyRef.name to match common.externalSecret.pull.secrets key if changed.
-  optEnv:
-    - name: SLACK_WEBHOOK_URL
-      valueFrom:
-        secretKeyRef:
-          name: elastalert-slack-webhook
-          key: slack_webhook_url
-          optional: true
+  # optEnv:
+  #   - name: SLACK_WEBHOOK_URL
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: elastalert-slack-webhook
+  #         key: slack_webhook_url
+
   secretRulesName: elastalert-custom-rules
   secretRulesList:
     - argoCD


### PR DESCRIPTION
## Summary

- Adds the `iits common` sub-chart as a dependency to enable opt-in ExternalSecrets (ESO) support
- When `common.externalSecret.enabled=true`, an `ExternalSecret` pulls the Slack webhook URL from the configured secret store (e.g. Vault) into a K8s Secret, which the pod reads as `SLACK_WEBHOOK_URL` via `optEnv`
- The `custom_rules` template now auto-injects `slack_webhook_url` into every rule — either the direct value (`customRules.slack.webhookUrl`) or the `${SLACK_WEBHOOK_URL}` env var reference when ESO is active; individual rules can still override with their own `slack_webhook_url`
- Both installation approaches (ESO and ArgoCD vault plugin) are documented in the README and `Chart.yaml`

## Tests

- [x] Helm unit tests added for all cases
- [x] ESO `ExternalSecret` rendering tested including custom `remoteKey`
- [x] `helm unittest charts/elastalert` passes all tests
- [x] Deploy to dev cluster with ESO enabled and the Slack webhook is picked up correctly