### PR TITLE
fix(common): fix ExternalSecret template.type reading from wrong values and add tests

### DIFF
--- a/charts/common/Changelog.md
+++ b/charts/common/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Chart Versions
 
+### 0.3.1
+- Fix ExternalSecret `template.type` being read from the wrong values level (`$secretConfig.type` instead of `$secretConfig.template.type`)
+
 ### 0.3.0
 - Remove hardcoded `argocd.argoproj.io/sync-wave` annotations from ExternalSecret/PushSecret/Password resources. Consumers needing sync ordering must now supply via per-secret/per-generator `annotations` field.
 - Add `annotations` field on each secret/generator config — merged into resource `metadata.annotations`.

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
-appVersion: v0.3.0
-version: 0.3.0
+appVersion: v0.3.1
+version: 0.3.1

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between charts. This chart is not deployable by itself.
 

--- a/charts/common/templates/external-secret.yaml
+++ b/charts/common/templates/external-secret.yaml
@@ -22,7 +22,7 @@ spec:
     {{- if .template }}
     template:
       engineVersion: v2
-      type: {{ .type | default "Opaque" }}
+      type: {{ .template.type | default "Opaque" }}
       {{- with .template.metadata }}
       metadata:
         {{- toYaml . | nindent 8 }}

--- a/charts/common/tests/external-secret_test.yaml
+++ b/charts/common/tests/external-secret_test.yaml
@@ -237,3 +237,45 @@ tests:
                 name: my-secret
                 items:
                   - key: some-key
+  - it: should default template type to Opaque when not specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          template:
+            data:
+              some-key: "some-value"
+    asserts:
+      - equal:
+          path: spec.target.template.type
+          value: Opaque
+
+  - it: should use custom template type when specified
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          template:
+            type: "kubernetes.io/tls"
+            data:
+              tls.crt: "{{ .cert }}"
+              tls.key: "{{ .key }}"
+    asserts:
+      - equal:
+          path: spec.target.template.type
+          value: "kubernetes.io/tls"
+
+  - it: should not render template block when template is not configured
+    set:
+      externalSecret.enabled: true
+      externalSecret.pull.enabled: true
+      externalSecret.pull.secrets:
+        test:
+          path: "test/path"
+          keys:
+            - name: myKey
+    asserts:
+      - notExists:
+          path: spec.target.template


### PR DESCRIPTION
- fixes inconsistency in how a secrets type is set
- adds tests for:
  - template.type defaults to Opaque when not specified
  - template.type renders correctly when set to a non-Opaque type
  - template block is absent when not configured (this might already be covered indirectly)