### PR TITLE
fix(kyverno): guard existingSecretRef ClusterPolicies behind enabled flag

### DIFF
--- a/charts/kyverno/Changelog.md
+++ b/charts/kyverno/Changelog.md
@@ -2,6 +2,14 @@
 
 ## Chart Versions
 
+## [3.2.2]
+### Fixed
+- template range loop for ClusterPolicy causing secrets to be cloned into all namespaces even when autoInjectDockerPullSecrets feature was explicitly disabled
+
+### Added
+- guard for secretRef[*].name beeing set, allowing empty .namespace to clone from secret in chart's namespace
+- yaml document end clause (---) to template
+
 ### 3.2.1
 - Handle naming collisions in imagePullSecrets
 

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -18,5 +18,5 @@ dependencies:
     version: 3.7.2
     condition: policy-reporter.install
 type: application
-version: 3.2.1
+version: 3.2.2
 appVersion: 1.15.3

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -1,6 +1,6 @@
 # kyverno
 
-![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
+![Version: 3.2.2](https://img.shields.io/badge/Version-3.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 
 This chart wraps the upstream `kyverno` and `kyverno-policies` chart and adds a few useful policies:
   - Verify all images are signed with cosign

--- a/charts/kyverno/templates/policies/add-image-pull-secrets.yaml
+++ b/charts/kyverno/templates/policies/add-image-pull-secrets.yaml
@@ -42,7 +42,7 @@ spec:
 ---
 # This section creates new secrets from the specifications in the chart values
 {{- range $registryName,$registryValues := .secrets }}
-{{ with $dockerconfigjson := printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $registryValues.registryUrl (printf "%s:%s" $registryValues.username $registryValues.password | b64enc) | b64enc }}
+{{- with $dockerconfigjson := printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $registryValues.registryUrl (printf "%s:%s" $registryValues.username $registryValues.password | b64enc) | b64enc }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -83,9 +83,11 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
----
+
 # This section creates the policies to clone from the existing secrets
+{{- if .Values.autoInjectDockerPullSecrets.enabled }}
 {{- range $existingSecretRef := .Values.autoInjectDockerPullSecrets.existingSecretRef }}
+{{- if $existingSecretRef.name -}}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -108,5 +110,8 @@ spec:
         namespace: '{{"{{request.object.metadata.name}}"}}'
         clone:
           name: {{ $existingSecretRef.name }}
-          namespace: {{ $existingSecretRef.namespace }}
+          namespace: {{ $existingSecretRef.namespace | default $.Release.Namespace }}
+---
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The range loop generating **auto-create-docker-*** ClusterPolicies for **existingSecretRef** entries was outside the **autoInjectDockerPullSecrets.enabled** guard, causing secrets to be cloned into all namespaces even when the feature was explicitly disabled.

Fix:
- added guard for enabled flag
- added guard for secretRef[*].name beeing set, allowing empty .namespace to clone from secret in chart's namespace
- added yaml document end clause (---) 