### PR TITLE
feat(argocd-apps): add rawDirectory flag to opt out of helm rendering

### DIFF
--- a/charts/argocd-apps/templates/application.yaml
+++ b/charts/argocd-apps/templates/application.yaml
@@ -23,6 +23,10 @@ spec:
     path: {{ $project.git.path | default $projectName }}
     repoURL: {{ $project.git.repoUrl }}
     targetRevision: {{ $project.git.branch | default "main" }}
+    {{- if $project.git.rawDirectory }}
+    directory:
+      recurse: false
+    {{- else }}
     helm:
       values: |
         {{- $project.tofuValues | toYaml | nindent 10}}
@@ -31,5 +35,6 @@ spec:
       {{- if ((($project.tofuValues).projectValues).stage) }}
         - values-{{ $project.tofuValues.projectValues.stage }}.yaml
       {{- end }}
+    {{- end }}
 ---
 {{- end }}

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -36,6 +36,7 @@ projects: {}
 #       secretStoreName: ""        # Name of the secret store object created in K8s
 #       accessType: ""             # Options: https or ssh
 #       secretPath: ""             # Path to the secret in the targeted Hashicorp Vault
+#       rawDirectory: false        # Optional, defaults to false. Set to true for plain Kubernetes YAML sources (e.g. ApplicationSets) to opt out of Helm rendering.
 
 #     # helm registries credentials
 #     helmRegistries:


### PR DESCRIPTION
When rawDirectory=true in the project git config, the ArgoCD Application uses a plain directory source instead of Helm. Needed for sources that contain raw Kubernetes YAML (e.g. ApplicationSets) rather than a chart.