### PR TITLE
(prometheus-stack): update to chart version 87.21.0

### DIFF
--- a/charts/prometheus-stack/CHANGELOG.md
+++ b/charts/prometheus-stack/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Chart Versions
 
+### 87.21.0
+- Update `kube-prometheus-stack` to 87.21.0
+
 ### 79.12.0
 - Increase version of `kube-prometheus-stack` to 79.12.0
 - Increase container restart report firing to >4

--- a/charts/prometheus-stack/Chart.lock
+++ b/charts/prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 79.12.0
+  version: 87.21.0
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 11.5.0
 - name: common
   repository: https://charts.iits.tech
-  version: 0.3.1
-digest: sha256:8025152d1815ba4ae0c253b4b79e6d543a020bc8b33d1050651d594d3831f652
-generated: "2026-07-03T11:49:54.224905+02:00"
+  version: 0.4.0
+digest: sha256:94566e5bd63c74aa75f5607fb9ed4bb59ad69d352852c5a3c7d043b48926443a
+generated: "2026-07-30T11:19:50.367068+02:00"

--- a/charts/prometheus-stack/Chart.yaml
+++ b/charts/prometheus-stack/Chart.yaml
@@ -3,7 +3,7 @@ dependencies:
   - alias: prometheusStack
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 79.12.0
+    version: 87.21.0
   - alias: blackboxExporter
     condition: blackboxExporter.enabled
     name: prometheus-blackbox-exporter
@@ -11,7 +11,7 @@ dependencies:
     version: 11.5.0
   - name: common
     repository: https://charts.iits.tech
-    version: 0.3.1
+    version: 0.4.0
 description: |
   A complete monitoring/alerting stack with Grafana, Prometheus, Alertmanager & Blackbox exporter
 
@@ -39,5 +39,5 @@ description: |
       prometheusStack.grafana.adminPassword: "REPLACE_ME"
   ```
 name: prometheus-stack
-version: 79.12.0
+version: 87.21.0
 appVersion: 3.9.0


### PR DESCRIPTION
Tested in PFAU. We are still using the old secret injection method so ESO is untested. Also note that updating from 79.12.0 or earlier requires updating the CRDs before applying the chart.